### PR TITLE
Added support for Alveo U250

### DIFF
--- a/board/rocket-freq
+++ b/board/rocket-freq
@@ -20,6 +20,12 @@ vcu1525       Rocket.*m4            80.0
 vcu1525       Rocket.*m2            100.0
 vcu1525       Rocket.*              125.0
 
+u250       Rocket64.*gem         31.25
+u250       Rocket64[xyz].*       40.0
+u250       Rocket.*b[2-9][0-9].* 80.0
+u250       Rocket.*b1[0-9].*     100.0
+u250       Rocket.*              125.0
+
 .*            Rocket.*gem       20.0
 .*            Rocket.*l2w?      31.25
 .*            Rocket64[xyz].*   20.0

--- a/board/u250/Makefile.inc
+++ b/board/u250/Makefile.inc
@@ -1,0 +1,9 @@
+BOARD_PART  ?= xilinx.com:au250:part0:1.3
+XILINX_PART ?= xcu250-figd2104-2L-e
+CFG_DEVICE  ?= SPIx4 -size 128
+CFG_PART    ?= mt25qu01g-spi-x1_x2_x4
+CFG_BOOT    ?= -loaddata {up 0x07000000 workspace/boot.elf}
+MEMORY_SIZE ?= 0x400000000
+ETHER_MAC   ?= 00 0a 35 00 00 03
+ETHER_PHY   ?= 10gbase-r
+ROOTFS      ?= NFS

--- a/board/u250/bootrom.dts
+++ b/board/u250/bootrom.dts
@@ -1,0 +1,35 @@
+/ {
+
+    aliases {
+        serial0 = &uart0;
+    };
+
+    chosen {
+        stdout-path = "serial0";
+    };
+
+    io-bus {
+        #address-cells = <1>;
+        #size-cells = <1>;
+        compatible = "rocketchip-vivado-io", "simple-bus";
+        ranges;
+
+        uart0: uart@60010000 {
+            compatible = "riscv,axi-uart-1.0";
+            reg = <0x60010000 0x10000>;
+            interrupt-parent = <&{/soc/interrupt-controller@c000000}>;
+            interrupts = <1>;
+            port-number = <0>;
+        };
+
+        eth: eth0@60020000 {
+            compatible = "riscv,axi-ethernet-1.0";
+            reg = <0x60020000 0x10000>;
+            phy-mode = "10gbase-r";
+            local-mac-address = [00 0a 35 00 00 00];
+            interrupt-parent = <&{/soc/interrupt-controller@c000000}>;
+            interrupts = <3>;
+        };
+
+    };
+};

--- a/board/u250/ethernet-u250.tcl
+++ b/board/u250/ethernet-u250.tcl
@@ -1,0 +1,55 @@
+set files [list \
+  [file normalize "../../board/${vivado_board_name}/riscv_wrapper.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_mac_10g.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_mac_10g_fifo.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_tx.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_if.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_tx_if.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_ber_mon.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_frame_sync.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_watchdog.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_rx_32.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_rx_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_tx_32.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_tx_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/xgmii_baser_dec_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/xgmii_baser_enc_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/sync_reset.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_adapter.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_async_fifo.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_async_fifo_adapter.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/lfsr.v"] \
+  [file normalize "../../ethernet/ethernet.v"] \
+]
+add_files -norecurse -fileset $source_fileset $files
+
+set files [list \
+  [file normalize ../../board/${vivado_board_name}/ethernet.xdc] \
+  [file normalize ../../ethernet/verilog-ethernet/lib/axis/syn/vivado/sync_reset.tcl] \
+  [file normalize ../../ethernet/verilog-ethernet/lib/axis/syn/vivado/axis_async_fifo.tcl] \
+  [file normalize ../../ethernet/verilog-ethernet/syn/vivado/eth_mac_fifo.tcl] \
+]
+add_files -norecurse -fileset $constraint_fileset $files
+
+create_ip -name gtwizard_ultrascale -vendor xilinx.com -library ip -module_name gtwizard_ultrascale_0
+
+set_property -dict [list CONFIG.preset {GTY-10GBASE-R}] [get_ips gtwizard_ultrascale_0]
+
+set_property -dict [list \
+    CONFIG.CHANNEL_ENABLE {X1Y44} \
+    CONFIG.TX_MASTER_CHANNEL {X1Y44} \
+    CONFIG.RX_MASTER_CHANNEL {X1Y44} \
+    CONFIG.TX_LINE_RATE {10.3125} \
+    CONFIG.TX_REFCLK_FREQUENCY {161.1328125} \
+    CONFIG.TX_USER_DATA_WIDTH {64} \
+    CONFIG.TX_INT_DATA_WIDTH {64} \
+    CONFIG.RX_LINE_RATE {10.3125} \
+    CONFIG.RX_REFCLK_FREQUENCY {161.1328125} \
+    CONFIG.RX_USER_DATA_WIDTH {64} \
+    CONFIG.RX_INT_DATA_WIDTH {64} \
+    CONFIG.RX_REFCLK_SOURCE {X1Y44 clk1} \
+    CONFIG.TX_REFCLK_SOURCE {X1Y44 clk1} \
+    CONFIG.FREERUN_FREQUENCY {125} \
+] [get_ips gtwizard_ultrascale_0]

--- a/board/u250/ethernet-u250.v
+++ b/board/u250/ethernet-u250.v
@@ -1,0 +1,400 @@
+/*
+
+Copyright (c) 2021 Eugene Tarassov
+Copyright (c) 2014-2018 Alex Forencich
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+module ethernet_u250 #(
+    // Timestamping configuration (port)
+    parameter PTP_TS_ENABLE = 0,
+    parameter TX_PTP_TS_FIFO_DEPTH = 32,
+    parameter RX_PTP_TS_FIFO_DEPTH = 32
+
+) (
+
+    (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 clock CLK" *)
+    (* X_INTERFACE_PARAMETER = "FREQ_HZ 125000000" *)
+    input wire clock,
+
+    input wire clock_ok,
+
+    output wire eth_gt_user_clock,
+
+    output wire [15:0] eth0_status,
+
+    /* ETH0 AXIS */
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TDATA" *)
+    input wire [63:0] eth0_tx_axis_tdata,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TKEEP" *)
+    input wire [7:0] eth0_tx_axis_tkeep,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TVALID" *)
+    input wire eth0_tx_axis_tvalid,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TREADY" *)
+    output wire eth0_tx_axis_tready,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TLAST" *)
+    input wire eth0_tx_axis_tlast,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_TX_AXIS TUSER" *)
+    input wire eth0_tx_axis_tuser,
+
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TDATA" *)
+    output wire [63:0] eth0_rx_axis_tdata,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TKEEP" *)
+    output wire [7:0] eth0_rx_axis_tkeep,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TVALID" *)
+    output wire eth0_rx_axis_tvalid,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TREADY" *)
+    input wire eth0_rx_axis_tready,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TLAST" *)
+    output wire eth0_rx_axis_tlast,
+    (* X_INTERFACE_INFO = "xilinx.com:interface:axis:1.0 ETH0_RX_AXIS TUSER" *)
+    output wire eth0_rx_axis_tuser,
+
+    /* QSFP28 #0 */
+    output wire         qsfp0_tx1_p,
+    output wire         qsfp0_tx1_n,
+    input  wire         qsfp0_rx1_p,
+    input  wire         qsfp0_rx1_n,
+    input  wire         qsfp0_mgt_refclk_1_p,
+    input  wire         qsfp0_mgt_refclk_1_n,
+    output wire         qsfp0_modsell,
+    output wire         qsfp0_resetl,
+    input  wire         qsfp0_modprsl,
+    input  wire         qsfp0_intl,
+    output wire         qsfp0_lpmode,
+    output wire         qsfp0_refclk_reset,
+    output wire [1:0]   qsfp0_fs
+
+);
+
+// PTP configuration
+localparam PTP_TS_WIDTH = 96;
+localparam PTP_TAG_WIDTH = 16;
+localparam PTP_PERIOD_NS_WIDTH = 4;
+localparam PTP_OFFSET_NS_WIDTH = 32;
+localparam PTP_FNS_WIDTH = 32;
+localparam PTP_PERIOD_NS = 4'd4;
+localparam PTP_PERIOD_FNS = 32'd0;
+localparam PTP_USE_SAMPLE_CLOCK = 0;
+localparam IF_PTP_PERIOD_NS = 6'h6;
+localparam IF_PTP_PERIOD_FNS = 16'h6666;
+
+// Interface configuration (port)
+localparam TX_CHECKSUM_ENABLE = 1;
+localparam RX_RSS_ENABLE = 1;
+localparam RX_HASH_ENABLE = 1;
+localparam RX_CHECKSUM_ENABLE = 1;
+localparam ENABLE_PADDING = 1;
+localparam ENABLE_DIC = 1;
+localparam MIN_FRAME_LENGTH = 64;
+localparam TX_FIFO_DEPTH = 32768;
+localparam RX_FIFO_DEPTH = 32768;
+localparam MAX_TX_SIZE = 9214;
+localparam MAX_RX_SIZE = 9214;
+localparam TX_RAM_SIZE = 32768;
+localparam RX_RAM_SIZE = 32768;
+
+// Ethernet interface configuration
+localparam XGMII_DATA_WIDTH = 64;
+localparam XGMII_CTRL_WIDTH = XGMII_DATA_WIDTH/8;
+localparam AXIS_ETH_DATA_WIDTH = XGMII_DATA_WIDTH;
+localparam AXIS_ETH_KEEP_WIDTH = AXIS_ETH_DATA_WIDTH/8;
+localparam AXIS_ETH_SYNC_DATA_WIDTH = AXIS_ETH_DATA_WIDTH;
+localparam AXIS_ETH_TX_USER_WIDTH = (PTP_TS_ENABLE ? PTP_TAG_WIDTH : 0) + 1;
+localparam AXIS_ETH_RX_USER_WIDTH = (PTP_TS_ENABLE ? PTP_TS_WIDTH : 0) + 1;
+localparam AXIS_ETH_STATUS_WIDTH = 16;
+
+// Internal 125 MHz clock
+wire clk_125mhz_int = clock;
+reg rst_125mhz_int = 1;
+reg [9:0] reset_timer_reg = 0;
+wire rst_refclk_int;
+
+sync_reset #(
+    .N(4)
+)
+sync_reset_125mhz_inst (
+    .clk(clk_125mhz_int),
+    .rst(~clock_ok),
+    .out(rst_refclk_int)
+);
+
+always @(posedge clk_125mhz_int) begin
+    if (rst_refclk_int) begin reset_timer_reg <= 0; rst_125mhz_int <= 1; end
+    else if (&reset_timer_reg) rst_125mhz_int <= 0;
+    else reset_timer_reg <= reset_timer_reg + 1;
+end
+
+
+// XGMII 10G PHY
+assign qsfp0_refclk_reset = rst_refclk_int;
+assign qsfp0_fs = 2'b10;
+
+wire                         rx_rst;
+wire [XGMII_DATA_WIDTH-1:0]  qsfp0_txd_1;
+wire [XGMII_CTRL_WIDTH-1:0]  qsfp0_txc_1;
+wire [XGMII_DATA_WIDTH-1:0]  qsfp0_rxd_1;
+wire [XGMII_CTRL_WIDTH-1:0]  qsfp0_rxc_1;
+wire [6:0]                   qsfp0_rx_error_count_1;
+
+wire qsfp0_rx_block_lock_1;
+wire qsfp0_rx_block_lock_2;
+wire qsfp0_rx_block_lock_3;
+wire qsfp0_rx_block_lock_4;
+
+wire qsfp_gtpowergood;
+
+wire qsfp0_mgt_refclk_1;
+
+wire sfp_gt_txclkout;
+
+// Internal 156.25 MHz clock
+wire tx_clk;
+wire tx_rst;
+
+wire sfp_gt_rxclkout;
+wire rx_clk;
+
+wire gt_reset_tx_done;
+wire gt_reset_rx_done;
+
+wire gt_txprgdivresetdone;
+wire gt_txpmaresetdone;
+wire gt_rxprgdivresetdone;
+wire gt_rxpmaresetdone;
+
+wire gt_tx_reset = ~((&gt_txprgdivresetdone) & (&gt_txpmaresetdone));
+wire gt_rx_reset = ~&gt_rxpmaresetdone;
+
+reg gt_userclk_tx_active = 1'b0;
+reg gt_userclk_rx_active = 1'b0;
+
+IBUFDS_GTE4 ibufds_gte4_qsfp0_mgt_refclk_1_inst (
+    .I             (qsfp0_mgt_refclk_1_p),
+    .IB            (qsfp0_mgt_refclk_1_n),
+    .CEB           (1'b0),
+    .O             (qsfp0_mgt_refclk_1),
+    .ODIV2         ()
+);
+
+BUFG_GT bufg_gt_tx_usrclk_inst (
+    .CE      (1'b1),
+    .CEMASK  (1'b0),
+    .CLR     (gt_tx_reset),
+    .CLRMASK (1'b0),
+    .DIV     (3'd0),
+    .I       (sfp_gt_txclkout),
+    .O       (tx_clk)
+);
+
+always @(posedge tx_clk, posedge gt_tx_reset) begin
+    if (gt_tx_reset) begin
+        gt_userclk_tx_active <= 1'b0;
+    end else begin
+        gt_userclk_tx_active <= 1'b1;
+    end
+end
+
+BUFG_GT bufg_gt_rx_usrclk_inst (
+    .CE      (1'b1),
+    .CEMASK  (1'b0),
+    .CLR     (gt_rx_reset),
+    .CLRMASK (1'b0),
+    .DIV     (3'd0),
+    .I       (sfp_gt_rxclkout),
+    .O       (rx_clk)
+);
+
+always @(posedge rx_clk, posedge gt_rx_reset) begin
+    if (gt_rx_reset) begin
+        gt_userclk_rx_active <= 1'b0;
+    end else begin
+        gt_userclk_rx_active <= 1'b1;
+    end
+end
+
+sync_reset #(
+    .N(4)
+)
+sync_reset_156mhz_inst (
+    .clk(tx_clk),
+    .rst(~gt_reset_tx_done),
+    .out(tx_rst)
+);
+
+wire [5:0] qsfp0_gt_txheader_1;
+wire [63:0] qsfp0_gt_txdata_1;
+wire qsfp0_gt_rxgearboxslip_1;
+wire [5:0] qsfp0_gt_rxheader_1;
+wire [1:0] qsfp0_gt_rxheadervalid_1;
+wire [63:0] qsfp0_gt_rxdata_1;
+wire [1:0] qsfp0_gt_rxdatavalid_1;
+
+gtwizard_ultrascale_0
+qsfp0_gt1_inst (
+    .gtwiz_userclk_tx_active_in(gt_userclk_tx_active),
+    .gtwiz_userclk_rx_active_in(gt_userclk_rx_active),
+
+    .gtwiz_reset_clk_freerun_in(clk_125mhz_int),
+    .gtwiz_reset_all_in(rst_125mhz_int),
+
+    .gtwiz_reset_tx_pll_and_datapath_in(1'b0),
+    .gtwiz_reset_tx_datapath_in(1'b0),
+
+    .gtwiz_reset_rx_pll_and_datapath_in(1'b0),
+    .gtwiz_reset_rx_datapath_in(1'b0),
+
+    .gtwiz_reset_rx_cdr_stable_out(),
+
+    .gtwiz_reset_tx_done_out(gt_reset_tx_done),
+    .gtwiz_reset_rx_done_out(gt_reset_rx_done),
+
+    .gtrefclk00_in(qsfp0_mgt_refclk_1),
+
+    .qpll0outclk_out(),
+    .qpll0outrefclk_out(),
+
+    .gtyrxn_in(qsfp0_rx1_n),
+    .gtyrxp_in(qsfp0_rx1_p),
+
+    .rxusrclk_in(rx_clk),
+    .rxusrclk2_in(rx_clk),
+
+    .gtwiz_userdata_tx_in(qsfp0_gt_txdata_1),
+    .txheader_in(qsfp0_gt_txheader_1),
+    .txsequence_in(1'b0),
+
+    .txusrclk_in(tx_clk),
+    .txusrclk2_in(tx_clk),
+
+    .gtpowergood_out(qsfp_gtpowergood),
+
+    .gtytxn_out(qsfp0_tx1_n),
+    .gtytxp_out(qsfp0_tx1_p),
+
+    .rxgearboxslip_in(qsfp0_gt_rxgearboxslip_1),
+    .gtwiz_userdata_rx_out(qsfp0_gt_rxdata_1),
+    .rxdatavalid_out(qsfp0_gt_rxdatavalid_1),
+    .rxheader_out(qsfp0_gt_rxheader_1),
+    .rxheadervalid_out(qsfp0_gt_rxheadervalid_1),
+    .rxoutclk_out(sfp_gt_rxclkout),
+    .rxpmaresetdone_out(gt_rxpmaresetdone),
+    .rxprgdivresetdone_out(gt_rxprgdivresetdone),
+    .rxstartofseq_out(),
+
+    .txoutclk_out(sfp_gt_txclkout),
+    .txpmaresetdone_out(gt_txpmaresetdone),
+    .txprgdivresetdone_out(gt_txprgdivresetdone)
+);
+
+sync_reset #(
+    .N(4)
+)
+qsfp0_rx_rst_1_reset_sync_inst (
+    .clk(rx_clk),
+    .rst(~gt_reset_rx_done),
+    .out(rx_rst)
+);
+
+eth_phy_10g #(
+    .BIT_REVERSE(1)
+)
+qsfp0_phy_1_inst (
+    .tx_clk(tx_clk),
+    .tx_rst(tx_rst),
+    .rx_clk(rx_clk),
+    .rx_rst(rx_rst),
+    .xgmii_txd(qsfp0_txd_1),
+    .xgmii_txc(qsfp0_txc_1),
+    .xgmii_rxd(qsfp0_rxd_1),
+    .xgmii_rxc(qsfp0_rxc_1),
+    .serdes_tx_data(qsfp0_gt_txdata_1),
+    .serdes_tx_hdr(qsfp0_gt_txheader_1),
+    .serdes_rx_data(qsfp0_gt_rxdata_1),
+    .serdes_rx_hdr(qsfp0_gt_rxheader_1),
+    .serdes_rx_bitslip(qsfp0_gt_rxgearboxslip_1),
+    .rx_error_count(qsfp0_rx_error_count_1),
+    .rx_block_lock(qsfp0_rx_block_lock_1),
+    .rx_high_ber(),
+    .tx_prbs31_enable(0),
+    .rx_prbs31_enable(0)
+);
+
+assign eth_gt_user_clock = tx_clk;
+
+eth_mac_10g_fifo #(
+    .DATA_WIDTH(AXIS_ETH_DATA_WIDTH),
+    .ENABLE_PADDING(ENABLE_PADDING),
+    .ENABLE_DIC(ENABLE_DIC),
+    .MIN_FRAME_LENGTH(MIN_FRAME_LENGTH),
+    .PTP_PERIOD_NS(IF_PTP_PERIOD_NS),
+    .PTP_PERIOD_FNS(IF_PTP_PERIOD_FNS),
+    .PTP_TS_WIDTH(PTP_TS_WIDTH),
+    .PTP_TAG_WIDTH(PTP_TAG_WIDTH),
+    .TX_PTP_TS_ENABLE(PTP_TS_ENABLE),
+    .TX_PTP_TAG_ENABLE(PTP_TS_ENABLE),
+    .RX_PTP_TS_ENABLE(PTP_TS_ENABLE),
+    .TX_FIFO_DEPTH(4096),
+    .TX_FRAME_FIFO(1),
+    .RX_FIFO_DEPTH(4096),
+    .RX_FRAME_FIFO(1)
+)
+eth_mac_10g_fifo_inst (
+    .rx_clk(rx_clk),
+    .rx_rst(rx_rst),
+    .tx_clk(tx_clk),
+    .tx_rst(tx_rst),
+    .logic_clk(tx_clk),
+    .logic_rst(tx_rst),
+
+    .tx_axis_tdata(eth0_tx_axis_tdata),
+    .tx_axis_tkeep(eth0_tx_axis_tkeep),
+    .tx_axis_tuser(eth0_tx_axis_tuser),
+    .tx_axis_tvalid(eth0_tx_axis_tvalid),
+    .tx_axis_tready(eth0_tx_axis_tready),
+    .tx_axis_tlast(eth0_tx_axis_tlast),
+
+    .rx_axis_tdata(eth0_rx_axis_tdata),
+    .rx_axis_tkeep(eth0_rx_axis_tkeep),
+    .rx_axis_tuser(eth0_rx_axis_tuser),
+    .rx_axis_tvalid(eth0_rx_axis_tvalid),
+    .rx_axis_tready(eth0_rx_axis_tready),
+    .rx_axis_tlast(eth0_rx_axis_tlast),
+
+    .xgmii_rxd(qsfp0_rxd_1),
+    .xgmii_rxc(qsfp0_rxc_1),
+    .xgmii_txd(qsfp0_txd_1),
+    .xgmii_txc(qsfp0_txc_1),
+
+    .tx_fifo_overflow(eth0_status[0]),
+    .tx_fifo_bad_frame(eth0_status[1]),
+    .tx_fifo_good_frame(eth0_status[2]),
+    .tx_error_underflow(eth0_status[3]),
+    .rx_error_bad_frame(eth0_status[4]),
+    .rx_error_bad_fcs(eth0_status[5]),
+    .rx_fifo_overflow(eth0_status[6]),
+    .rx_fifo_bad_frame(eth0_status[7]),
+    .rx_fifo_good_frame(eth0_status[8]),
+
+    .ifg_delay(8'd12)
+);
+
+endmodule

--- a/board/u250/ethernet.xdc
+++ b/board/u250/ethernet.xdc
@@ -1,0 +1,86 @@
+# QSFP28 Interfaces
+set_property -dict {LOC N4  } [get_ports qsfp0_rx1_p] ;# MGTYRXP0_231 GTYE4_CHANNEL_X1Y44 / GTYE4_COMMON_X1Y11
+set_property -dict {LOC N3  } [get_ports qsfp0_rx1_n] ;# MGTYRXN0_231 GTYE4_CHANNEL_X1Y44 / GTYE4_COMMON_X1Y11
+set_property -dict {LOC N9  } [get_ports qsfp0_tx1_p] ;# MGTYTXP0_231 GTYE4_CHANNEL_X1Y44 / GTYE4_COMMON_X1Y11
+set_property -dict {LOC N8  } [get_ports qsfp0_tx1_n] ;# MGTYTXN0_231 GTYE4_CHANNEL_X1Y44 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC M2  } [get_ports qsfp0_rx2_p] ;# MGTYRXP1_231 GTYE4_CHANNEL_X1Y45 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC M1  } [get_ports qsfp0_rx2_n] ;# MGTYRXN1_231 GTYE4_CHANNEL_X1Y45 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC M7  } [get_ports qsfp0_tx2_p] ;# MGTYTXP1_231 GTYE4_CHANNEL_X1Y45 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC M6  } [get_ports qsfp0_tx2_n] ;# MGTYTXN1_231 GTYE4_CHANNEL_X1Y45 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC L4  } [get_ports qsfp0_rx3_p] ;# MGTYRXP2_231 GTYE4_CHANNEL_X1Y46 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC L3  } [get_ports qsfp0_rx3_n] ;# MGTYRXN2_231 GTYE4_CHANNEL_X1Y46 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC L9  } [get_ports qsfp0_tx3_p] ;# MGTYTXP2_231 GTYE4_CHANNEL_X1Y46 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC L8  } [get_ports qsfp0_tx3_n] ;# MGTYTXN2_231 GTYE4_CHANNEL_X1Y46 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC K2  } [get_ports qsfp0_rx4_p] ;# MGTYRXP3_231 GTYE4_CHANNEL_X1Y47 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC K1  } [get_ports qsfp0_rx4_n] ;# MGTYRXN3_231 GTYE4_CHANNEL_X1Y47 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC K7  } [get_ports qsfp0_tx4_p] ;# MGTYTXP3_231 GTYE4_CHANNEL_X1Y47 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC K6  } [get_ports qsfp0_tx4_n] ;# MGTYTXN3_231 GTYE4_CHANNEL_X1Y47 / GTYE4_COMMON_X1Y11
+#set_property -dict {LOC M11 } [get_ports qsfp0_mgt_refclk_0_p] ;# MGTREFCLK0P_231 from U14.4 via U43.13
+#set_property -dict {LOC M10 } [get_ports qsfp0_mgt_refclk_0_n] ;# MGTREFCLK0N_231 from U14.5 via U43.14
+set_property -dict {LOC K11 } [get_ports qsfp0_mgt_refclk_1_p] ;# MGTREFCLK1P_231 from U9.18
+set_property -dict {LOC K10 } [get_ports qsfp0_mgt_refclk_1_n] ;# MGTREFCLK1N_231 from U9.17
+set_property -dict {LOC BE16 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp0_modsell]
+set_property -dict {LOC BE17 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp0_resetl]
+set_property -dict {LOC BE20 IOSTANDARD LVCMOS12 PULLUP true} [get_ports qsfp0_modprsl]
+set_property -dict {LOC BE21 IOSTANDARD LVCMOS12 PULLUP true} [get_ports qsfp0_intl]
+set_property -dict {LOC BD18 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp0_lpmode]
+set_property -dict {LOC AT22 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp0_refclk_reset]
+set_property -dict {LOC AT20 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports {qsfp0_fs[0]}]
+set_property -dict {LOC AU22 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports {qsfp0_fs[1]}]
+
+# 156.25 MHz MGT reference clock (from SI570)
+#create_clock -period 6.400 -name qsfp0_mgt_refclk_0 [get_ports qsfp0_mgt_refclk_0_p]
+
+# 156.25 MHz MGT reference clock (from SI5335, FS = 0b01)
+#create_clock -period 6.400 -name qsfp0_mgt_refclk_1 [get_ports qsfp0_mgt_refclk_1_p]
+
+# 161.1328125 MHz MGT reference clock (from SI5335, FS = 0b10)
+create_clock -period 6.206 -name qsfp0_mgt_refclk_1 [get_ports qsfp0_mgt_refclk_1_p]
+
+set_false_path -to [get_ports {qsfp0_modsell qsfp0_resetl qsfp0_lpmode qsfp0_refclk_reset qsfp0_fs[*]}]
+set_output_delay 0 [get_ports {qsfp0_modsell qsfp0_resetl qsfp0_lpmode qsfp0_refclk_reset qsfp0_fs[*]}]
+set_false_path -from [get_ports {qsfp0_modprsl qsfp0_intl}]
+set_input_delay 0 [get_ports {qsfp0_modprsl qsfp0_intl}]
+
+#set_property -dict {LOC U4  } [get_ports qsfp1_rx1_p] ;# MGTYRXP0_230 GTYE4_CHANNEL_X1Y40 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC U3  } [get_ports qsfp1_rx1_n] ;# MGTYRXN0_230 GTYE4_CHANNEL_X1Y40 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC U9  } [get_ports qsfp1_tx1_p] ;# MGTYTXP0_230 GTYE4_CHANNEL_X1Y40 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC U8  } [get_ports qsfp1_tx1_n] ;# MGTYTXN0_230 GTYE4_CHANNEL_X1Y40 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC T2  } [get_ports qsfp1_rx2_p] ;# MGTYRXP1_230 GTYE4_CHANNEL_X1Y41 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC T1  } [get_ports qsfp1_rx2_n] ;# MGTYRXN1_230 GTYE4_CHANNEL_X1Y41 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC T7  } [get_ports qsfp1_tx2_p] ;# MGTYTXP1_230 GTYE4_CHANNEL_X1Y41 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC T6  } [get_ports qsfp1_tx2_n] ;# MGTYTXN1_230 GTYE4_CHANNEL_X1Y41 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC R4  } [get_ports qsfp1_rx3_p] ;# MGTYRXP2_230 GTYE4_CHANNEL_X1Y42 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC R3  } [get_ports qsfp1_rx3_n] ;# MGTYRXN2_230 GTYE4_CHANNEL_X1Y42 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC R9  } [get_ports qsfp1_tx3_p] ;# MGTYTXP2_230 GTYE4_CHANNEL_X1Y42 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC R8  } [get_ports qsfp1_tx3_n] ;# MGTYTXN2_230 GTYE4_CHANNEL_X1Y42 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC P2  } [get_ports qsfp1_rx4_p] ;# MGTYRXP3_230 GTYE4_CHANNEL_X1Y43 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC P1  } [get_ports qsfp1_rx4_n] ;# MGTYRXN3_230 GTYE4_CHANNEL_X1Y43 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC P7  } [get_ports qsfp1_tx4_p] ;# MGTYTXP3_230 GTYE4_CHANNEL_X1Y43 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC P6  } [get_ports qsfp1_tx4_n] ;# MGTYTXN3_230 GTYE4_CHANNEL_X1Y43 / GTYE4_COMMON_X1Y10
+#set_property -dict {LOC T11 } [get_ports qsfp1_mgt_refclk_0_p] ;# MGTREFCLK0P_230 from U14.4 via U43.15
+#set_property -dict {LOC T10 } [get_ports qsfp1_mgt_refclk_0_n] ;# MGTREFCLK0N_230 from U14.5 via U43.16
+#set_property -dict {LOC P11 } [get_ports qsfp1_mgt_refclk_1_p] ;# MGTREFCLK1P_230 from U12.18
+#set_property -dict {LOC P10 } [get_ports qsfp1_mgt_refclk_1_n] ;# MGTREFCLK1N_230 from U12.17
+#set_property -dict {LOC AY20 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp1_modsell]
+#set_property -dict {LOC BC18 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp1_resetl]
+#set_property -dict {LOC BC19 IOSTANDARD LVCMOS12 PULLUP true} [get_ports qsfp1_modprsl]
+#set_property -dict {LOC AV21 IOSTANDARD LVCMOS12 PULLUP true} [get_ports qsfp1_intl]
+#set_property -dict {LOC AV22 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp1_lpmode]
+#set_property -dict {LOC AR21 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports qsfp1_refclk_reset]
+#set_property -dict {LOC AR22 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports {qsfp1_fs[0]}]
+#set_property -dict {LOC AU20 IOSTANDARD LVCMOS12 SLEW SLOW DRIVE 8} [get_ports {qsfp1_fs[1]}]
+
+# 156.25 MHz MGT reference clock (from SI570)
+#create_clock -period 6.400 -name qsfp1_mgt_refclk_0 [get_ports qsfp1_mgt_refclk_0_p]
+
+# 156.25 MHz MGT reference clock (from SI5335, FS = 0b01)
+#create_clock -period 6.400 -name qsfp1_mgt_refclk_1 [get_ports qsfp1_mgt_refclk_1_p]
+
+# 161.1328125 MHz MGT reference clock (from SI5335, FS = 0b10)
+#create_clock -period 6.206 -name qsfp1_mgt_refclk_1 [get_ports qsfp1_mgt_refclk_1_p]
+
+#set_false_path -to [get_ports {qsfp1_modsell qsfp1_resetl qsfp1_lpmode qsfp1_refclk_reset qsfp1_fs[*]}]
+#set_output_delay 0 [get_ports {qsfp1_modsell qsfp1_resetl qsfp1_lpmode qsfp1_refclk_reset qsfp1_fs[*]}]
+#set_false_path -from [get_ports {qsfp1_modprsl qsfp1_intl}]
+#set_input_delay 0 [get_ports {qsfp1_modprsl qsfp1_intl}]

--- a/board/u250/riscv-2020.2.tcl
+++ b/board/u250/riscv-2020.2.tcl
@@ -1,0 +1,704 @@
+
+################################################################
+# This is a generated script based on design: riscv
+#
+# Though there are limitations about the generated script,
+# the main purpose of this utility is to make learning
+# IP Integrator Tcl commands easier.
+################################################################
+
+namespace eval _tcl {
+proc get_script_folder {} {
+   set script_path [file normalize [info script]]
+   set script_folder [file dirname $script_path]
+   return $script_folder
+}
+}
+variable script_folder
+set script_folder [_tcl::get_script_folder]
+
+################################################################
+# Check if script is running in correct Vivado version.
+################################################################
+set scripts_vivado_version 2020.2
+set current_vivado_version [version -short]
+
+if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
+   puts ""
+   catch {common::send_gid_msg -ssname BD::TCL -id 2041 -severity "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
+
+   return 1
+}
+
+################################################################
+# START
+################################################################
+
+# To test this script, run the following commands from Vivado Tcl console:
+# source riscv_script.tcl
+
+
+# The design that will be created by this Tcl script contains the following
+# module references:
+# $rocket_module_name, synchronizer, uart, ethernet
+
+# Please add the sources of those modules before sourcing this Tcl script.
+
+# If there is no project opened, this script will create a
+# project, but make sure you do not have an existing project
+# <./myproj/project_1.xpr> in the current working folder.
+
+set list_projs [get_projects -quiet]
+if { $list_projs eq "" } {
+   create_project project_1 myproj -part xcu250-figd2104-2L-e
+   set_property BOARD_PART xilinx.com:au250:part0:1.3 [current_project]
+}
+
+
+# CHANGE DESIGN NAME HERE
+variable design_name
+set design_name riscv
+
+# If you do not already have an existing IP Integrator design open,
+# you can create a design using the following command:
+#    create_bd_design $design_name
+
+# Creating design if needed
+set errMsg ""
+set nRet 0
+
+set cur_design [current_bd_design -quiet]
+set list_cells [get_bd_cells -quiet]
+
+if { ${design_name} eq "" } {
+   # USE CASES:
+   #    1) Design_name not set
+
+   set errMsg "Please set the variable <design_name> to a non-empty value."
+   set nRet 1
+
+} elseif { ${cur_design} ne "" && ${list_cells} eq "" } {
+   # USE CASES:
+   #    2): Current design opened AND is empty AND names same.
+   #    3): Current design opened AND is empty AND names diff; design_name NOT in project.
+   #    4): Current design opened AND is empty AND names diff; design_name exists in project.
+
+   if { $cur_design ne $design_name } {
+      common::send_gid_msg -ssname BD::TCL -id 2001 -severity "INFO" "Changing value of <design_name> from <$design_name> to <$cur_design> since current design is empty."
+      set design_name [get_property NAME $cur_design]
+   }
+   common::send_gid_msg -ssname BD::TCL -id 2002 -severity "INFO" "Constructing design in IPI design <$cur_design>..."
+
+} elseif { ${cur_design} ne "" && $list_cells ne "" && $cur_design eq $design_name } {
+   # USE CASES:
+   #    5) Current design opened AND has components AND same names.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 1
+} elseif { [get_files -quiet ${design_name}.bd] ne "" } {
+   # USE CASES:
+   #    6) Current opened design, has components, but diff names, design_name exists in project.
+   #    7) No opened design, design_name exists in project.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 2
+
+} else {
+   # USE CASES:
+   #    8) No opened design, design_name not in project.
+   #    9) Current opened design, has components, but diff names, design_name not in project.
+
+   common::send_gid_msg -ssname BD::TCL -id 2003 -severity "INFO" "Currently there is no design <$design_name> in project, so creating one..."
+
+   create_bd_design $design_name
+
+   common::send_gid_msg -ssname BD::TCL -id 2004 -severity "INFO" "Making design <$design_name> as current_bd_design."
+   current_bd_design $design_name
+
+}
+
+common::send_gid_msg -ssname BD::TCL -id 2005 -severity "INFO" "Currently the variable <design_name> is equal to \"$design_name\"."
+
+if { $nRet != 0 } {
+   catch {common::send_gid_msg -ssname BD::TCL -id 2006 -severity "ERROR" $errMsg}
+   return $nRet
+}
+
+set bCheckIPsPassed 1
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\
+xilinx.com:ip:clk_wiz:6.0\
+xilinx.com:ip:util_vector_logic:2.0\
+xilinx.com:ip:ddr4:2.2\
+xilinx.com:ip:smartconnect:1.0\
+xilinx.com:ip:axi_iic:2.0\
+xilinx.com:ip:qdma:4.0\
+xilinx.com:ip:util_ds_buf:2.1\
+xilinx.com:ip:xlconcat:2.1\
+xilinx.com:ip:xlconstant:1.1\
+"
+
+   set list_ips_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+   if { $list_ips_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2012 -severity "ERROR" "The following IPs are not found in the IP Catalog:\n  $list_ips_missing\n\nResolution: Please add the repository containing the IP(s) to the project." }
+      set bCheckIPsPassed 0
+   }
+
+}
+
+##################################################################
+# CHECK Modules
+##################################################################
+set bCheckModules 1
+if { $bCheckModules == 1 } {
+   set list_check_mods "\
+$rocket_module_name\
+synchronizer\
+uart\
+ethernet\
+"
+
+   set list_mods_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2020 -severity "INFO" "Checking if the following modules exist in the project's sources: $list_check_mods ."
+
+   foreach mod_vlnv $list_check_mods {
+      if { [can_resolve_reference $mod_vlnv] == 0 } {
+         lappend list_mods_missing $mod_vlnv
+      }
+   }
+
+   if { $list_mods_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2021 -severity "ERROR" "The following module(s) are not found in the project: $list_mods_missing" }
+      common::send_gid_msg -ssname BD::TCL -id 2022 -severity "INFO" "Please add source files for the missing module(s) above."
+      set bCheckIPsPassed 0
+   }
+}
+
+if { $bCheckIPsPassed != 1 } {
+  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
+  return 3
+}
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+# Hierarchical cell: IO
+proc create_hier_cell_IO { parentCell nameHier } {
+
+  variable script_folder
+
+  if { $parentCell eq "" || $nameHier eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2092 -severity "ERROR" "create_hier_cell_IO() - Empty argument(s)!"}
+     return
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+  # Create cell and set as current instance
+  set hier_obj [create_bd_cell -type hier $nameHier]
+  current_bd_instance $hier_obj
+
+  # Create interface pins
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 M00_AXI
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 M01_AXI
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S01_AXI
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:axis_rtl:1.0 eth_rx_axis
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 eth_tx_axis
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:iic_rtl:1.0 iic_main
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:pcie_7x_mgt_rtl:1.0 pci_express_x16
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 pcie_refclk
+
+
+  # Create pins
+  create_bd_pin -dir I -type clk axi_clock
+  create_bd_pin -dir I -type rst axi_reset
+  create_bd_pin -dir I -type clk clock100MHz
+  create_bd_pin -dir I -type clk eth_gt_user_clock
+  create_bd_pin -dir I -from 15 -to 0 eth_status
+  create_bd_pin -dir O -from 7 -to 0 interrupts
+  create_bd_pin -dir I -type rst pcie_perstn
+  create_bd_pin -dir I -type clk sdram_clock
+  create_bd_pin -dir I usb_uart_rxd
+  create_bd_pin -dir O usb_uart_txd
+  create_bd_pin -dir O user_lnk_up
+
+  # Create instance: IIC, and set properties
+  set IIC [ create_bd_cell -type ip -vlnv xilinx.com:ip:axi_iic:2.0 IIC ]
+  set_property -dict [ list \
+   CONFIG.IIC_BOARD_INTERFACE {iic_main} \
+   CONFIG.USE_BOARD_FLOW {true} \
+ ] $IIC
+
+  # Create instance: UART, and set properties
+  set block_name uart
+  set block_cell_name UART
+  if { [catch {set UART [create_bd_cell -type module -reference $block_name $block_cell_name] } errmsg] } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2095 -severity "ERROR" "Unable to add referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   } elseif { $UART eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2096 -severity "ERROR" "Unable to referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   }
+
+  # Create instance: Ethernet, and set properties
+  set block_name ethernet
+  set block_cell_name Ethernet
+  if { [catch {set Ethernet [create_bd_cell -type module -reference $block_name $block_cell_name] } errmsg] } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2095 -severity "ERROR" "Unable to add referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   } elseif { $Ethernet eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2096 -severity "ERROR" "Unable to referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   }
+    set_property -dict [ list \
+   CONFIG.axis_word_bits {64} \
+   CONFIG.burst_size {64} \
+   CONFIG.dma_word_bits {64} \
+   CONFIG.dma_addr_bits {40} \
+   CONFIG.enable_mdio {0} \
+ ] $Ethernet
+
+  # Create instance: qdma_0, and set properties
+  set qdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:qdma:4.0 qdma_0 ]
+  set_property -dict [ list \
+   CONFIG.PCIE_BOARD_INTERFACE {pci_express_x8} \
+   CONFIG.PF0_MSIX_CAP_TABLE_SIZE_qdma {000} \
+   CONFIG.PF0_SRIOV_VF_DEVICE_ID {A038} \
+   CONFIG.PF1_SRIOV_VF_DEVICE_ID {A138} \
+   CONFIG.PF2_SRIOV_VF_DEVICE_ID {A238} \
+   CONFIG.PF3_SRIOV_VF_DEVICE_ID {A338} \
+   CONFIG.SYS_RST_N_BOARD_INTERFACE {pcie_perstn} \
+   CONFIG.axi_data_width {256_bit} \
+   CONFIG.axisten_freq {125} \
+   CONFIG.cfg_mgmt_if {false} \
+   CONFIG.coreclk_freq {250} \
+   CONFIG.dma_intf_sel_qdma {AXI_MM} \
+   CONFIG.en_gt_selection {true} \
+   CONFIG.mode_selection {Basic} \
+   CONFIG.pf0_bar2_scale_qdma {Megabytes} \
+   CONFIG.pf0_device_id {9028} \
+   CONFIG.pf0_msix_enabled_qdma {false} \
+   CONFIG.pf0_pciebar2axibar_2 {0x0000000060000000} \
+   CONFIG.pf1_bar2_scale_qdma {Megabytes} \
+   CONFIG.pf2_bar2_scale_qdma {Megabytes} \
+   CONFIG.pf2_device_id {9228} \
+   CONFIG.pf3_bar2_scale_qdma {Megabytes} \
+   CONFIG.pf3_device_id {9328} \
+   CONFIG.pl_link_cap_max_link_speed {5.0_GT/s} \
+   CONFIG.pl_link_cap_max_link_width {X8} \
+   CONFIG.plltype {QPLL1} \
+ ] $qdma_0
+
+  # Create instance: smartconnect_0, and set properties
+  set smartconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_0 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {5} \
+   CONFIG.NUM_MI {4} \
+   CONFIG.NUM_SI {2} \
+ ] $smartconnect_0
+
+  # Create instance: smartconnect_2, and set properties
+  set smartconnect_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_2 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {3} \
+   CONFIG.NUM_SI {2} \
+ ] $smartconnect_2
+
+  # Create instance: util_ds_buf, and set properties
+  set util_ds_buf [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.1 util_ds_buf ]
+  set_property -dict [ list \
+   CONFIG.C_BUF_TYPE {IBUFDSGTE} \
+   CONFIG.DIFF_CLK_IN_BOARD_INTERFACE {pcie_refclk} \
+   CONFIG.USE_BOARD_FLOW {true} \
+ ] $util_ds_buf
+
+  # Create instance: xlconcat_0, and set properties
+  set xlconcat_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 xlconcat_0 ]
+  set_property -dict [ list \
+   CONFIG.NUM_PORTS {8} \
+ ] $xlconcat_0
+
+  # Create instance: xlconstant_0, and set properties
+  set xlconstant_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+   CONFIG.CONST_WIDTH {1} \
+ ] $xlconstant_0
+
+  # Create instance: xlconstant_1, and set properties
+  set xlconstant_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_1 ]
+
+  # Create instance: xlconstant_2, and set properties
+  set xlconstant_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_2 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+ ] $xlconstant_2
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net Conn1 [get_bd_intf_pins pcie_refclk] [get_bd_intf_pins util_ds_buf/CLK_IN_D]
+  connect_bd_intf_net -intf_net Conn2 [get_bd_intf_pins eth_tx_axis] [get_bd_intf_pins Ethernet/TX_AXIS]
+  connect_bd_intf_net -intf_net Conn3 [get_bd_intf_pins eth_rx_axis] [get_bd_intf_pins Ethernet/RX_AXIS]
+  connect_bd_intf_net -intf_net RocketChip_IO_AXI4 [get_bd_intf_pins S01_AXI] [get_bd_intf_pins smartconnect_0/S01_AXI]
+  connect_bd_intf_net -intf_net axi_iic_0_IIC [get_bd_intf_pins iic_main] [get_bd_intf_pins IIC/IIC]
+  connect_bd_intf_net -intf_net Ethernet_M_AXI [get_bd_intf_pins Ethernet/M_AXI] [get_bd_intf_pins smartconnect_2/S01_AXI]
+  connect_bd_intf_net -intf_net qdma_0_M_AXI [get_bd_intf_pins qdma_0/M_AXI] [get_bd_intf_pins smartconnect_2/S00_AXI]
+  connect_bd_intf_net -intf_net qdma_0_M_AXI_LITE [get_bd_intf_pins qdma_0/M_AXI_LITE] [get_bd_intf_pins smartconnect_0/S00_AXI]
+  connect_bd_intf_net -intf_net qdma_0_pcie_mgt [get_bd_intf_pins pci_express_x16] [get_bd_intf_pins qdma_0/pcie_mgt]
+  connect_bd_intf_net -intf_net smartconnect_0_M00_AXI [get_bd_intf_pins IIC/S_AXI] [get_bd_intf_pins smartconnect_0/M00_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins M01_AXI] [get_bd_intf_pins smartconnect_0/M01_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M02_AXI [get_bd_intf_pins UART/S_AXI_LITE] [get_bd_intf_pins smartconnect_0/M02_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M03_AXI [get_bd_intf_pins Ethernet/S_AXI_LITE] [get_bd_intf_pins smartconnect_0/M03_AXI]
+  connect_bd_intf_net -intf_net smartconnect_2_M00_AXI [get_bd_intf_pins M00_AXI] [get_bd_intf_pins smartconnect_2/M00_AXI]
+
+  # Create port connections
+  connect_bd_net -net DDR_clock [get_bd_pins sdram_clock] [get_bd_pins smartconnect_0/aclk1]
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins axi_reset] [get_bd_pins UART/async_resetn] [get_bd_pins Ethernet/async_resetn] [get_bd_pins smartconnect_0/aresetn] [get_bd_pins smartconnect_2/aresetn]
+  connect_bd_net -net RocketChip_clock [get_bd_pins axi_clock] [get_bd_pins smartconnect_0/aclk2] [get_bd_pins smartconnect_2/aclk1]
+  connect_bd_net -net axi_iic_0_iic2intc_irpt [get_bd_pins IIC/iic2intc_irpt] [get_bd_pins xlconcat_0/In3]
+  connect_bd_net -net clock100MHz [get_bd_pins clock100MHz] [get_bd_pins UART/clock] [get_bd_pins smartconnect_0/aclk3]
+  connect_bd_net -net eth_gt_user_clock_1 [get_bd_pins eth_gt_user_clock] [get_bd_pins Ethernet/clock] [get_bd_pins smartconnect_0/aclk4] [get_bd_pins smartconnect_2/aclk2]
+  connect_bd_net -net Ethernet_interrupt [get_bd_pins Ethernet/interrupt] [get_bd_pins xlconcat_0/In2]
+  connect_bd_net -net interrupts [get_bd_pins interrupts] [get_bd_pins xlconcat_0/dout]
+  connect_bd_net -net pcie_perstn [get_bd_pins pcie_perstn] [get_bd_pins qdma_0/sys_rst_n]
+  connect_bd_net -net qdma_0_axi_aclk [get_bd_pins IIC/s_axi_aclk] [get_bd_pins qdma_0/axi_aclk] [get_bd_pins smartconnect_0/aclk] [get_bd_pins smartconnect_2/aclk]
+  connect_bd_net -net qdma_0_axi_aresetn [get_bd_pins IIC/s_axi_aresetn] [get_bd_pins qdma_0/axi_aresetn]
+  connect_bd_net -net qdma_0_user_lnk_up [get_bd_pins user_lnk_up] [get_bd_pins qdma_0/user_lnk_up]
+  connect_bd_net -net status_vector_0_1 [get_bd_pins eth_status] [get_bd_pins Ethernet/status_vector]
+  connect_bd_net -net usb_uart_rxd [get_bd_pins usb_uart_rxd] [get_bd_pins UART/RxD]
+  connect_bd_net -net usb_uart_txd [get_bd_pins usb_uart_txd] [get_bd_pins UART/TxD]
+  connect_bd_net -net uart_0_interrupt [get_bd_pins UART/interrupt] [get_bd_pins xlconcat_0/In0]
+  connect_bd_net -net util_ds_buf_IBUF_DS_ODIV2 [get_bd_pins qdma_0/sys_clk] [get_bd_pins util_ds_buf/IBUF_DS_ODIV2]
+  connect_bd_net -net util_ds_buf_IBUF_OUT [get_bd_pins qdma_0/sys_clk_gt] [get_bd_pins util_ds_buf/IBUF_OUT]
+  connect_bd_net -net xlconstant_0_dout [get_bd_pins Ethernet/mdio_int] [get_bd_pins xlconcat_0/In1] [get_bd_pins xlconcat_0/In4] [get_bd_pins xlconcat_0/In5] [get_bd_pins xlconcat_0/In6] [get_bd_pins xlconcat_0/In7] [get_bd_pins xlconstant_0/dout]
+  connect_bd_net -net xlconstant_1_dout [get_bd_pins qdma_0/soft_reset_n] [get_bd_pins xlconstant_1/dout]
+  connect_bd_net -net xlconstant_2_dout [get_bd_pins UART/CTSn] [get_bd_pins xlconstant_2/dout]
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+}
+
+# Hierarchical cell: DDR
+proc create_hier_cell_DDR { parentCell nameHier } {
+
+  variable script_folder
+
+  if { $parentCell eq "" || $nameHier eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2092 -severity "ERROR" "create_hier_cell_DDR() - Empty argument(s)!"}
+     return
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+  # Create cell and set as current instance
+  set hier_obj [create_bd_cell -type hier $nameHier]
+  current_bd_instance $hier_obj
+
+  # Create interface pins
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 C0_DDR4_S_AXI_CTRL
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S00_AXI
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram_c0
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_300mhz_clk0
+
+
+  # Create pins
+  create_bd_pin -dir I axi_clock
+  create_bd_pin -dir I axi_reset
+  create_bd_pin -dir O -type clk c0_ddr4_ui_clk
+  create_bd_pin -dir O c0_init_calib_complete
+  create_bd_pin -dir I -type rst sys_reset
+
+  # Create instance: ddr4_0, and set properties
+  set ddr4_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ddr4:2.2 ddr4_0 ]
+  set_property -dict [ list \
+   CONFIG.C0_CLOCK_BOARD_INTERFACE {default_300mhz_clk0} \
+   CONFIG.C0_DDR4_BOARD_INTERFACE {ddr4_sdram_c0} \
+   CONFIG.RESET_BOARD_INTERFACE {resetn} \
+ ] $ddr4_0
+
+  # Create instance: smartconnect_1, and set properties
+  set smartconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_1 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {2} \
+   CONFIG.NUM_SI {1} \
+ ] $smartconnect_1
+
+  # Create instance: synchronizer_0, and set properties
+  set block_name synchronizer
+  set block_cell_name synchronizer_0
+  if { [catch {set synchronizer_0 [create_bd_cell -type module -reference $block_name $block_cell_name] } errmsg] } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2095 -severity "ERROR" "Unable to add referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   } elseif { $synchronizer_0 eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2096 -severity "ERROR" "Unable to referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   }
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net RocketChip_MEM_AXI4 [get_bd_intf_pins S00_AXI] [get_bd_intf_pins smartconnect_1/S00_AXI]
+  connect_bd_intf_net -intf_net ddr4_0_C0_DDR4 [get_bd_intf_pins ddr4_sdram_c0] [get_bd_intf_pins ddr4_0/C0_DDR4]
+  connect_bd_intf_net -intf_net default_300mhz_clk0_1 [get_bd_intf_pins default_300mhz_clk0] [get_bd_intf_pins ddr4_0/C0_SYS_CLK]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins C0_DDR4_S_AXI_CTRL] [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI_CTRL]
+  connect_bd_intf_net -intf_net smartconnect_1_M00_AXI [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI] [get_bd_intf_pins smartconnect_1/M00_AXI]
+
+  # Create port connections
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins axi_reset] [get_bd_pins smartconnect_1/aresetn] [get_bd_pins synchronizer_0/dinp]
+  connect_bd_net -net axi_clock [get_bd_pins axi_clock] [get_bd_pins smartconnect_1/aclk]
+  connect_bd_net -net ddr4_0_c0_ddr4_ui_clk [get_bd_pins c0_ddr4_ui_clk] [get_bd_pins ddr4_0/c0_ddr4_ui_clk] [get_bd_pins smartconnect_1/aclk1] [get_bd_pins synchronizer_0/clock]
+  connect_bd_net -net ddr4_0_c0_init_calib_complete [get_bd_pins c0_init_calib_complete] [get_bd_pins ddr4_0/c0_init_calib_complete]
+  connect_bd_net -net resetn_inv_0_Res [get_bd_pins sys_reset] [get_bd_pins ddr4_0/sys_rst]
+  connect_bd_net -net synchronizer_0_dout [get_bd_pins ddr4_0/c0_ddr4_aresetn] [get_bd_pins synchronizer_0/dout]
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+}
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+  set clk_user [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 clk_user ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   ] $clk_user
+
+  set ddr4_sdram_c0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram_c0 ]
+
+  set default_300mhz_clk0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_300mhz_clk0 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {300000000} \
+   ] $default_300mhz_clk0
+
+  set eth_rx_axis [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:axis_rtl:1.0 eth_rx_axis ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   CONFIG.HAS_TKEEP {1} \
+   CONFIG.HAS_TLAST {1} \
+   CONFIG.HAS_TREADY {1} \
+   CONFIG.HAS_TSTRB {0} \
+   CONFIG.LAYERED_METADATA {undef} \
+   CONFIG.TDATA_NUM_BYTES {8} \
+   CONFIG.TDEST_WIDTH {0} \
+   CONFIG.TID_WIDTH {0} \
+   CONFIG.TUSER_WIDTH {1} \
+   ] $eth_rx_axis
+
+  set eth_tx_axis [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 eth_tx_axis ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   ] $eth_tx_axis
+
+  set iic_main [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:iic_rtl:1.0 iic_main ]
+
+  set pci_express_x16 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:pcie_7x_mgt_rtl:1.0 pci_express_x16 ]
+
+  set pcie_refclk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 pcie_refclk ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {100000000} \
+   ] $pcie_refclk
+
+
+  # Create ports
+  set eth_clock [ create_bd_port -dir O -type clk eth_clock ]
+  set eth_clock_ok [ create_bd_port -dir O -type rst eth_clock_ok ]
+  set eth_gt_user_clock [ create_bd_port -dir I -type clk eth_gt_user_clock ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   ] $eth_gt_user_clock
+  set eth_status [ create_bd_port -dir I -from 15 -to 0 eth_status ]
+  set pcie_perstn [ create_bd_port -dir I -type rst pcie_perstn ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] $pcie_perstn
+  set resetn [ create_bd_port -dir I -type rst resetn ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] $resetn
+  set usb_uart_rxd [ create_bd_port -dir I usb_uart_rxd ]
+  set usb_uart_txd [ create_bd_port -dir O usb_uart_txd ]
+
+  # Create instance: DDR
+  create_hier_cell_DDR [current_bd_instance .] DDR
+
+  # Create instance: IO
+  create_hier_cell_IO [current_bd_instance .] IO
+
+  # Create instance: RocketChip, and set properties
+  global rocket_module_name
+  set RocketChip [create_bd_cell -type module -reference $rocket_module_name RocketChip]
+
+  # Create instance: clk_wiz_0, and set properties
+  set clk_wiz_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:6.0 clk_wiz_0 ]
+  set_property -dict [ list \
+   CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {125.0} \
+   CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125.000} \
+   CONFIG.CLKOUT2_USED {true} \
+   CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {100.000} \
+   CONFIG.CLKOUT3_USED {true} \
+   CONFIG.NUM_OUT_CLKS {3} \
+   CONFIG.PRIM_SOURCE {Differential_clock_capable_pin} \
+   CONFIG.USE_PHASE_ALIGNMENT {true} \
+   CONFIG.USE_RESET {false} \
+ ] $clk_wiz_0
+
+  # Create instance: resetn_inv_0, and set properties
+  set resetn_inv_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 resetn_inv_0 ]
+  set_property -dict [ list \
+   CONFIG.C_OPERATION {not} \
+   CONFIG.C_SIZE {1} \
+ ] $resetn_inv_0
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net IO_TX_AXIS_0 [get_bd_intf_ports eth_tx_axis] [get_bd_intf_pins IO/eth_tx_axis]
+  connect_bd_intf_net -intf_net RX_AXIS_0_1 [get_bd_intf_ports eth_rx_axis] [get_bd_intf_pins IO/eth_rx_axis]
+  connect_bd_intf_net -intf_net RocketChip_IO_AXI4 [get_bd_intf_pins IO/S01_AXI] [get_bd_intf_pins RocketChip/IO_AXI4]
+  connect_bd_intf_net -intf_net RocketChip_MEM_AXI4 [get_bd_intf_pins DDR/S00_AXI] [get_bd_intf_pins RocketChip/MEM_AXI4]
+  connect_bd_intf_net -intf_net axi_iic_0_IIC [get_bd_intf_ports iic_main] [get_bd_intf_pins IO/iic_main]
+  connect_bd_intf_net -intf_net clk_user_1 [get_bd_intf_ports clk_user] [get_bd_intf_pins clk_wiz_0/CLK_IN1_D]
+  connect_bd_intf_net -intf_net ddr4_0_C0_DDR4 [get_bd_intf_ports ddr4_sdram_c0] [get_bd_intf_pins DDR/ddr4_sdram_c0]
+  connect_bd_intf_net -intf_net default_300mhz_clk0 [get_bd_intf_ports default_300mhz_clk0] [get_bd_intf_pins DDR/default_300mhz_clk0]
+  connect_bd_intf_net -intf_net pcie_refclk [get_bd_intf_ports pcie_refclk] [get_bd_intf_pins IO/pcie_refclk]
+  connect_bd_intf_net -intf_net qdma_0_pcie_mgt [get_bd_intf_ports pci_express_x16] [get_bd_intf_pins IO/pci_express_x16]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins DDR/C0_DDR4_S_AXI_CTRL] [get_bd_intf_pins IO/M01_AXI]
+  connect_bd_intf_net -intf_net smartconnect_2_M00_AXI [get_bd_intf_pins IO/M00_AXI] [get_bd_intf_pins RocketChip/DMA_AXI4]
+
+  # Create port connections
+  connect_bd_net -net DDR_clock [get_bd_pins DDR/c0_ddr4_ui_clk] [get_bd_pins IO/sdram_clock]
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins DDR/axi_reset] [get_bd_pins IO/axi_reset] [get_bd_pins RocketChip/aresetn]
+  connect_bd_net -net RocketChip_clock [get_bd_pins DDR/axi_clock] [get_bd_pins IO/axi_clock] [get_bd_pins RocketChip/clock] [get_bd_pins clk_wiz_0/clk_out1]
+  connect_bd_net -net clk_wiz_0_clk_out2 [get_bd_ports eth_clock] [get_bd_pins clk_wiz_0/clk_out2]
+  connect_bd_net -net clk_wiz_0_locked [get_bd_ports eth_clock_ok] [get_bd_pins RocketChip/clock_ok] [get_bd_pins clk_wiz_0/locked]
+  connect_bd_net -net clock100MHz_1 [get_bd_pins IO/clock100MHz] [get_bd_pins clk_wiz_0/clk_out3]
+  connect_bd_net -net ddr4_0_c0_init_calib_complete [get_bd_pins DDR/c0_init_calib_complete] [get_bd_pins RocketChip/mem_ok]
+  connect_bd_net -net eth_gt_user_clock_0_1 [get_bd_ports eth_gt_user_clock] [get_bd_pins IO/eth_gt_user_clock]
+  connect_bd_net -net interrupts [get_bd_pins IO/interrupts] [get_bd_pins RocketChip/interrupts]
+  connect_bd_net -net pcie_perstn [get_bd_ports pcie_perstn] [get_bd_pins IO/pcie_perstn]
+  connect_bd_net -net qdma_0_user_lnk_up [get_bd_pins IO/user_lnk_up] [get_bd_pins RocketChip/io_ok]
+  connect_bd_net -net reset [get_bd_pins DDR/sys_reset] [get_bd_pins RocketChip/sys_reset] [get_bd_pins resetn_inv_0/Res]
+  connect_bd_net -net resetn [get_bd_ports resetn] [get_bd_pins resetn_inv_0/Op1]
+  connect_bd_net -net status_vector_0_1 [get_bd_ports eth_status] [get_bd_pins IO/eth_status]
+  connect_bd_net -net usb_uart_rxd [get_bd_ports usb_uart_rxd] [get_bd_pins IO/usb_uart_rxd]
+  connect_bd_net -net usb_uart_txd [get_bd_ports usb_uart_txd] [get_bd_pins IO/usb_uart_txd]
+
+  # Create address segments
+  set addr_range [expr 1 << [get_property CONFIG.ADDR_WIDTH [get_bd_intf_pins RocketChip/MEM_AXI4]]]
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces RocketChip/MEM_AXI4] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] -force
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces IO/Ethernet/M_AXI] [get_bd_addr_segs RocketChip/DMA_AXI4/reg0] -force
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces IO/qdma_0/M_AXI] [get_bd_addr_segs RocketChip/DMA_AXI4/reg0] -force
+
+  assign_bd_address -offset 0x60010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs IO/UART/S_AXI_LITE/reg0] -force
+  assign_bd_address -offset 0x60010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces IO/qdma_0/M_AXI_LITE] [get_bd_addr_segs IO/UART/S_AXI_LITE/reg0] -force
+
+  assign_bd_address -offset 0x60020000 -range 0x00010000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs IO/Ethernet/S_AXI_LITE/reg0] -force
+  assign_bd_address -offset 0x60020000 -range 0x00010000 -target_address_space [get_bd_addr_spaces IO/qdma_0/M_AXI_LITE] [get_bd_addr_segs IO/Ethernet/S_AXI_LITE/reg0] -force
+
+  assign_bd_address -offset 0x60040000 -range 0x00010000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs IO/IIC/S_AXI/Reg] -force
+  assign_bd_address -offset 0x60040000 -range 0x00010000 -target_address_space [get_bd_addr_spaces IO/qdma_0/M_AXI_LITE] [get_bd_addr_segs IO/IIC/S_AXI/Reg] -force
+
+  assign_bd_address -offset 0x60100000 -range 0x00100000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] -force
+  assign_bd_address -offset 0x60100000 -range 0x00100000 -target_address_space [get_bd_addr_spaces IO/qdma_0/M_AXI_LITE] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] -force
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  validate_bd_design
+  save_bd_design
+}
+# End of create_root_design()
+
+
+##################################################################
+# MAIN FLOW
+##################################################################
+
+create_root_design ""

--- a/board/u250/riscv_wrapper.v
+++ b/board/u250/riscv_wrapper.v
@@ -1,0 +1,188 @@
+module riscv_wrapper (
+    input wire clk_user_clk_n,
+    input wire clk_user_clk_p,
+
+    /* DDR4 */
+    output wire ddr4_sdram_c0_act_n,
+    output wire [16:0]ddr4_sdram_c0_adr,
+    output wire [1:0]ddr4_sdram_c0_ba,
+    output wire [1:0]ddr4_sdram_c0_bg,
+    output wire ddr4_sdram_c0_ck_c,
+    output wire ddr4_sdram_c0_ck_t,
+    output wire ddr4_sdram_c0_cke,
+    output wire ddr4_sdram_c0_cs_n,
+    inout  wire [71:0]ddr4_sdram_c0_dq,
+    inout  wire [17:0]ddr4_sdram_c0_dqs_c,
+    inout  wire [17:0]ddr4_sdram_c0_dqs_t,
+    output wire ddr4_sdram_c0_odt,
+    output wire ddr4_sdram_c0_par,
+    output wire ddr4_sdram_c0_reset_n,
+    input  wire default_300mhz_clk0_clk_n,
+    input  wire default_300mhz_clk0_clk_p,
+
+    /* IIC */
+    inout  wire iic_main_scl_io,
+    inout  wire iic_main_sda_io,
+
+    /* PCIe */
+    input  wire [7:0]pci_express_x16_rxn,
+    input  wire [7:0]pci_express_x16_rxp,
+    output wire [7:0]pci_express_x16_txn,
+    output wire [7:0]pci_express_x16_txp,
+    input  wire pcie_perstn,
+    input  wire pcie_refclk_clk_n,
+    input  wire pcie_refclk_clk_p,
+    input  wire resetn,
+
+    /* UART */
+    input  wire usb_uart_rxd,
+    output wire usb_uart_txd,
+
+    /* QSFP28 #0 */
+    output wire         qsfp0_tx1_p,
+    output wire         qsfp0_tx1_n,
+    input  wire         qsfp0_rx1_p,
+    input  wire         qsfp0_rx1_n,
+    input  wire         qsfp0_mgt_refclk_1_p,
+    input  wire         qsfp0_mgt_refclk_1_n,
+    output wire         qsfp0_modsell,
+    output wire         qsfp0_resetl,
+    input  wire         qsfp0_modprsl,
+    input  wire         qsfp0_intl,
+    output wire         qsfp0_lpmode,
+    output wire         qsfp0_refclk_reset,
+    output wire [1:0]   qsfp0_fs
+    );
+
+wire iic_main_scl_i;
+wire iic_main_scl_o;
+wire iic_main_scl_t;
+
+IOBUF iic_main_scl_iobuf (
+    .I(iic_main_scl_o),
+    .IO(iic_main_scl_io),
+    .O(iic_main_scl_i),
+    .T(iic_main_scl_t));
+
+wire iic_main_sda_i;
+wire iic_main_sda_o;
+wire iic_main_sda_t;
+
+IOBUF iic_main_sda_iobuf (
+    .I(iic_main_sda_o),
+    .IO(iic_main_sda_io),
+    .O(iic_main_sda_i),
+    .T(iic_main_sda_t));
+
+// Ethernet phy initialization reset and clock
+wire eth_clock_ok;
+wire eth_clock;
+
+// Ethernet GT user clock
+wire eth_gt_user_clock;
+
+wire [63:0 ]eth_rx_axis_tdata;
+wire [7:0] eth_rx_axis_tkeep;
+wire eth_rx_axis_tlast;
+wire eth_rx_axis_tready;
+wire eth_rx_axis_tuser;
+wire eth_rx_axis_tvalid;
+wire [15:0] eth_status;
+wire [63:0] eth_tx_axis_tdata;
+wire [7:0] eth_tx_axis_tkeep;
+wire eth_tx_axis_tlast;
+wire eth_tx_axis_tready;
+wire eth_tx_axis_tuser;
+wire eth_tx_axis_tvalid;
+
+riscv riscv_i (
+    .clk_user_clk_n(clk_user_clk_n),
+    .clk_user_clk_p(clk_user_clk_p),
+    .ddr4_sdram_c0_act_n(ddr4_sdram_c0_act_n),
+    .ddr4_sdram_c0_adr(ddr4_sdram_c0_adr),
+    .ddr4_sdram_c0_ba(ddr4_sdram_c0_ba),
+    .ddr4_sdram_c0_bg(ddr4_sdram_c0_bg),
+    .ddr4_sdram_c0_ck_c(ddr4_sdram_c0_ck_c),
+    .ddr4_sdram_c0_ck_t(ddr4_sdram_c0_ck_t),
+    .ddr4_sdram_c0_cke(ddr4_sdram_c0_cke),
+    .ddr4_sdram_c0_cs_n(ddr4_sdram_c0_cs_n),
+    .ddr4_sdram_c0_dq(ddr4_sdram_c0_dq),
+    .ddr4_sdram_c0_dqs_c(ddr4_sdram_c0_dqs_c),
+    .ddr4_sdram_c0_dqs_t(ddr4_sdram_c0_dqs_t),
+    .ddr4_sdram_c0_odt(ddr4_sdram_c0_odt),
+    .ddr4_sdram_c0_par(ddr4_sdram_c0_par),
+    .ddr4_sdram_c0_reset_n(ddr4_sdram_c0_reset_n),
+    .default_300mhz_clk0_clk_n(default_300mhz_clk0_clk_n),
+    .default_300mhz_clk0_clk_p(default_300mhz_clk0_clk_p),
+    .eth_clock_ok(eth_clock_ok),
+    .eth_clock(eth_clock),
+    .eth_gt_user_clock(eth_gt_user_clock),
+    .eth_rx_axis_tdata(eth_rx_axis_tdata),
+    .eth_rx_axis_tkeep(eth_rx_axis_tkeep),
+    .eth_rx_axis_tlast(eth_rx_axis_tlast),
+    .eth_rx_axis_tready(eth_rx_axis_tready),
+    .eth_rx_axis_tuser(eth_rx_axis_tuser),
+    .eth_rx_axis_tvalid(eth_rx_axis_tvalid),
+    .eth_status(eth_status),
+    .eth_tx_axis_tdata(eth_tx_axis_tdata),
+    .eth_tx_axis_tkeep(eth_tx_axis_tkeep),
+    .eth_tx_axis_tlast(eth_tx_axis_tlast),
+    .eth_tx_axis_tready(eth_tx_axis_tready),
+    .eth_tx_axis_tuser(eth_tx_axis_tuser),
+    .eth_tx_axis_tvalid(eth_tx_axis_tvalid),
+    .iic_main_scl_i(iic_main_scl_i),
+    .iic_main_scl_o(iic_main_scl_o),
+    .iic_main_scl_t(iic_main_scl_t),
+    .iic_main_sda_i(iic_main_sda_i),
+    .iic_main_sda_o(iic_main_sda_o),
+    .iic_main_sda_t(iic_main_sda_t),
+    .pci_express_x16_rxn(pci_express_x16_rxn),
+    .pci_express_x16_rxp(pci_express_x16_rxp),
+    .pci_express_x16_txn(pci_express_x16_txn),
+    .pci_express_x16_txp(pci_express_x16_txp),
+    .pcie_perstn(pcie_perstn),
+    .pcie_refclk_clk_n(pcie_refclk_clk_n),
+    .pcie_refclk_clk_p(pcie_refclk_clk_p),
+    .resetn(resetn),
+    .usb_uart_rxd(usb_uart_rxd),
+    .usb_uart_txd(usb_uart_txd));
+
+ethernet_u250 ethernet_u250_i (
+    .clock_ok(eth_clock_ok),
+    .clock(eth_clock),
+
+    .eth_gt_user_clock(eth_gt_user_clock),
+
+    /* Ethernet #0 AXI Stream */
+    .eth0_rx_axis_tdata(eth_rx_axis_tdata),
+    .eth0_rx_axis_tkeep(eth_rx_axis_tkeep),
+    .eth0_rx_axis_tlast(eth_rx_axis_tlast),
+    .eth0_rx_axis_tready(eth_rx_axis_tready),
+    .eth0_rx_axis_tuser(eth_rx_axis_tuser),
+    .eth0_rx_axis_tvalid(eth_rx_axis_tvalid),
+    .eth0_status(eth_status),
+    .eth0_tx_axis_tdata(eth_tx_axis_tdata),
+    .eth0_tx_axis_tkeep(eth_tx_axis_tkeep),
+    .eth0_tx_axis_tlast(eth_tx_axis_tlast),
+    .eth0_tx_axis_tready(eth_tx_axis_tready),
+    .eth0_tx_axis_tuser(eth_tx_axis_tuser),
+    .eth0_tx_axis_tvalid(eth_tx_axis_tvalid),
+
+    /* QSFP28 #0 */
+    .qsfp0_tx1_p(qsfp0_tx1_p),
+    .qsfp0_tx1_n(qsfp0_tx1_n),
+    .qsfp0_rx1_p(qsfp0_rx1_p),
+    .qsfp0_rx1_n(qsfp0_rx1_n),
+    .qsfp0_mgt_refclk_1_p(qsfp0_mgt_refclk_1_p),
+    .qsfp0_mgt_refclk_1_n(qsfp0_mgt_refclk_1_n),
+    .qsfp0_modsell(qsfp0_modsell),
+    .qsfp0_resetl(qsfp0_resetl),
+    .qsfp0_modprsl(qsfp0_modprsl),
+    .qsfp0_intl(qsfp0_intl),
+    .qsfp0_lpmode(qsfp0_lpmode),
+    .qsfp0_refclk_reset(qsfp0_refclk_reset),
+    .qsfp0_fs(qsfp0_fs)
+
+);
+
+endmodule

--- a/board/u250/sdc.xdc
+++ b/board/u250/sdc.xdc
@@ -1,0 +1,1 @@
+# SD card not supported

--- a/board/u250/top.xdc
+++ b/board/u250/top.xdc
@@ -1,0 +1,12 @@
+set_property BITSTREAM.CONFIG.UNUSEDPIN pulldown [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS true [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 85.0 [current_design]
+set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]
+set_property CONFIG_VOLTAGE 1.8 [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]
+set_property CFGBVS GND [current_design]
+
+# SI570 user clock
+set_property -dict {LOC AV19 IOSTANDARD LVDS} [get_ports clk_user_clk_n]
+set_property -dict {LOC AU19 IOSTANDARD LVDS} [get_ports clk_user_clk_p]

--- a/board/u250/uart.xdc
+++ b/board/u250/uart.xdc
@@ -1,0 +1,3 @@
+# UART
+set_property -dict {PACKAGE_PIN BB20 IOSTANDARD LVCMOS12} [get_ports usb_uart_txd]
+set_property -dict {PACKAGE_PIN BF18 IOSTANDARD LVCMOS12} [get_ports usb_uart_rxd]


### PR DESCRIPTION
I used the VCU1525 source files under `board/` and modified them properly in order to support the Alveo U250. 

I also used the same default frequencies you have set for the VCU1525 in `board/rocket-freq` (I have not tested if those freqs can get better for the Alveo U250). Should I merge them as you have done with the genesys2/kc705 boards?

Thanks!