### PR TITLE
Allow BOARD_PART to be NONE and Enable write_cfgmem .bin binary output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ vivado      = env XILINX_LOCAL_USER_DATA=no vivado -mode batch -nojournal -nolog
 
 workspace/$(CONFIG)/system-$(BOARD).tcl: workspace/$(CONFIG)/rocket.vhdl
 	echo "set vivado_board_name $(BOARD)" >$@
-	echo "set vivado_board_part $(BOARD_PART)" >>$@
+	if [ ! "$(BOARD_PART)" = "NONE" ] ; then echo "set vivado_board_part $(BOARD_PART)" >>$@ ; fi
 	echo "set xilinx_part $(XILINX_PART)" >>$@
 	echo "set rocket_module_name $(CONFIG_SCALA)" >>$@
 	echo "set riscv_clock_frequency $(ROCKET_FREQ_MHZ)" >>$@

--- a/vivado.tcl
+++ b/vivado.tcl
@@ -2,7 +2,10 @@
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
    create_project ${vivado_board_name}-riscv vivado-${vivado_board_name}-riscv -part ${xilinx_part}
-   set_property BOARD_PART ${vivado_board_part} [current_project]
+   # Allow projects with no BOART_PART set. xilinx_part and /board constraints can suffice.
+   if {[info exists vivado_board_part]} {
+      set_property BOARD_PART ${vivado_board_part} [current_project]
+   }
 }
 
 # Create 'sources_1' fileset (if not found)


### PR DESCRIPTION
I am in the process of adding support for the [Innova-2 Flex MNV303212A-ADLT](https://www.nvidia.com/en-us/networking/ethernet/innova-2-flex/) XCKU15P-based board.

There is no official Board IP repository so I added the ability to set BOARD_PART to NONE. The contents of `top.xdc` are enough for such a board. It is just an FPGA with DDR4 connected to a PCIe Switch. There are no peripherals that need custom settings files or any other features of Board IP repositories.

The Innova-2 is programmed with `.bin` files so I added that as an option to `write_cfgmem`.