### PR TITLE
Update mk-sd-card

### DIFF
--- a/mk-sd-card
+++ b/mk-sd-card
@@ -28,6 +28,7 @@ for DEVICE in `ls /dev/disk/by-path/*-usb-*-scsi-*` ; do
     sudo dd if=$SD_IMG of=$DEVICE bs=64K status=progress
     sudo sync
     sudo partprobe ${DEVICE}
+    sleep 3
     echo ", +" | sudo sfdisk -N 2 ${DEVICE}
     sudo partprobe ${DEVICE}
     sudo fsck -f ${DEVICE}2


### PR DESCRIPTION
Sometimes, an error will occur when mk-sdcard, probably because I am using WSL 2 and there's a cache or delayed write issue about USBIP (Completely guessed)
Sleep for 3 seconds will eliminate this error.

![image](https://user-images.githubusercontent.com/29846655/216775147-bdcd4af8-0e47-446c-86cb-38264db83819.png)
