### PR TITLE
Update mk-sd-card

### DIFF
--- a/mk-sd-card
+++ b/mk-sd-card
@@ -21,7 +21,7 @@ for DEVICE in `ls /dev/disk/by-path/*-usb-*-scsi-*` ; do
   echo
   DEVICE=`realpath $DEVICE`
   echo "Copy disk image to:"
-  sudo sfdisk -l $DEVICE
+  sudo sfdisk -l $DEVICE || continue
   read -r -p "Are you sure? [y/N] " response
   case "$response" in
   [yY][eE][sS]|[yY])


### PR DESCRIPTION
Sometimes an SD card reader might have two physical slots that support SD and microSD in a single adapter, but the adapter creates two mass storage devices. If unluckily the SD slot is in front of the microSD slot, the script will try to read the empty medium and fail.

![image](https://user-images.githubusercontent.com/29846655/216815358-89e99e80-b364-4d86-a016-dea44b057c0a.png)

This tiny patch continues to try the next device.