### PR TITLE
Update Makefile to generate configuration memory file for Alveo U200/250

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,12 @@ endif
 
 $(cfgmem_file) $(prm_file): $(CFG_FILES)
 	echo "open_project $(proj_file)" >$(proj_path)/make-mcs.tcl
-	echo "write_cfgmem -format $(CFG_FORMAT) -interface $(CFG_DEVICE) -loadbit {up 0x0 $(bitstream)} $(CFG_BOOT) -file $(cfgmem_file) -force" >>$(proj_path)/make-mcs.tcl
+	if [ "$(BOARD)" = "u200" -o "$(BOARD)" = "u250" ] ; then \
+		echo "write_cfgmem -format $(CFG_FORMAT) -interface $(CFG_DEVICE) -loadbit {up 0x01002000 $(bitstream)} $(CFG_BOOT) -file $(cfgmem_file) -force" >>$(proj_path)/make-mcs.tcl ; \
+	else\
+		echo "write_cfgmem -format $(CFG_FORMAT) -interface $(CFG_DEVICE) -loadbit {up 0x0 $(bitstream)} $(CFG_BOOT) -file $(cfgmem_file) -force" >>$(proj_path)/make-mcs.tcl ; \
+	fi
+	# echo "write_cfgmem -format $(CFG_FORMAT) -interface $(CFG_DEVICE) -loadbit {up 0x0 $(bitstream)} $(CFG_BOOT) -file $(cfgmem_file) -force" >>$(proj_path)/make-mcs.tcl
 	$(vivado) -source $(proj_path)/make-mcs.tcl
 
 bitstream: $(bitstream) $(cfgmem_file)

--- a/bare-metal/README.md
+++ b/bare-metal/README.md
@@ -30,6 +30,7 @@ boot.elf can be downloaded directly into RISC-V memory and started using Xilinx 
 xsdb% connect
 tcfchan#0
 xsdb% targets -set -filter {name =~ "Hart #0*"}
+xsdb% stop
 xsdb% dow -clear boot.elf
 Downloading Program -- boot.elf
         section, .text: 0x80000000 - 0x8000b05f


### PR DESCRIPTION
UG1289 mentions: address 0x00000000 through 0x01001FFF is a write protected region which holds the card's golden recovery image and cannot be written to. The user_config_region_offset setting cannot be within this range.