### PR TITLE
Fix QEMU dependency detection issue

### DIFF
--- a/qemu/boot_qemu.sh
+++ b/qemu/boot_qemu.sh
@@ -7,7 +7,7 @@ fi
 if [ ! -e qemu/opensbi/build/platform/generic/firmware/fw_payload.bin ]
 then
     make u-boot-qemu
-    make opensbi
+    make opensbi-qemu
 fi
 
 qemu-system-riscv64 -machine virt -m 8G -nographic \

--- a/qemu/boot_qemu.sh
+++ b/qemu/boot_qemu.sh
@@ -1,8 +1,13 @@
 if [ ! -e debian-riscv64/debian-riscv64.sd.img ]
 then
     ./mk-sd-image
+fi
+
+# Check if OpenSBI exists, if not, build U-Boot and OpenSBI
+if [ ! -e qemu/opensbi/build/platform/generic/firmware/fw_payload.bin ]
+then
     make u-boot-qemu
-    make opensbi-qemu
+    make opensbi
 fi
 
 qemu-system-riscv64 -machine virt -m 8G -nographic \


### PR DESCRIPTION
If mk-sd-image or mk-sd-card was executed first, starting QEMU would not trigger the make process for U-Boot and OpenSBI.
This issue has been resolved by modifying the script.