### PR TITLE
Make it easier to externally parameterize this project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ apt-install-qemi:
 	sudo apt install qemu-system-misc opensbi u-boot-qemu qemu-utils
 
 # skip submodules which are not needed and take long time to update
-SKIP_SUBMODULES = torture software/gemmini-rocc-tests software/onnxruntime-riscv
+override SKIP_SUBMODULES += torture software/gemmini-rocc-tests software/onnxruntime-riscv
 
 update:
 	git pull --no-recurse-submodules

--- a/vivado.tcl
+++ b/vivado.tcl
@@ -93,8 +93,7 @@ regenerate_bd_layout
 save_bd_design
 
 if { [get_files -quiet -of_objects $source_fileset [list "*/riscv_wrapper.v"]] == "" } {
-  make_wrapper -files [get_files riscv.bd] -top
-  add_files -norecurse [file normalize vivado-${vivado_board_name}-riscv/${vivado_board_name}-riscv.srcs/sources_1/bd/riscv/hdl/riscv_wrapper.v ]
+  make_wrapper -files [get_files riscv.bd] -top -import
 }
 set_property top riscv_wrapper $source_fileset
 update_compile_order -fileset $source_fileset


### PR DESCRIPTION
For my use case, I want to include this project as a submodule in my own repo. I only need the block designs themselves and already have recursive submodules, so I would like to be able to exclude some submodules from this project. Additionally, I consume the generated TCL scripts for the block designs into my own project structure, which does not match the structure expected by add_files when importing the wrapper.