### PR TITLE
Genesys2 Rocket64w1 default frequency 80MHz for timing closure

### DIFF
--- a/board/rocket-freq
+++ b/board/rocket-freq
@@ -10,6 +10,7 @@ vc707         Rocket.*          100.0
 (genesys2|kc705|.*xc7k325t)  Rocket64x1            50.0
 (genesys2|kc705|.*xc7k325t)  Rocket64[xyz].*       31.25
 (genesys2|kc705|.*xc7k325t)  Rocket.*l2w?          62.5
+(genesys2|kc705|.*xc7k325t)  Rocket64w1            80.0
 (genesys2|kc705|.*xc7k325t)  Rocket.*b[4-9].*      80.0
 (genesys2|kc705|.*xc7k325t)  Rocket.*              100.0
 


### PR DESCRIPTION
Per https://github.com/eugene-tarassov/vivado-risc-v/issues/272, adjusting down from default 100MHz which was failing timing by ~1.6ns.
Ran full bitstream build to confirm it now passes timing, and tried it out successfully on real hardware as well.