### PR TITLE
Baremetal adding Dhrystone benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /project/target/
 /project/project/target/
 /generators/targetutils/target/
-/bare-metal/hello-world/boot.elf
+/bare-metal/*/boot.elf
 /.bash_history
 /.cache/
 /.config/

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "bare-metal/coremark/coremark"]
 	path = bare-metal/coremark/coremark
 	url = https://github.com/eembc/coremark.git
+[submodule "bare-metal/dhrystone/benchmark-dhrystone"]
+	path = bare-metal/dhrystone/benchmark-dhrystone
+	url = https://github.com/sifive/benchmark-dhrystone.git

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,6 +26,7 @@ This repository integrates multiple third-party components under their respectiv
 | gemmini          | [BSD-style (Berkeley)](https://github.com/ucb-bar/gemmini/blob/master/LICENSE) | Custom BSD variant from UC Berkeley |
 | opensbi          | [BSD 2-Clause](https://github.com/riscv-software-src/opensbi/blob/master/COPYING.BSD) | Permissive |
 | coremark         | [Apache 2.0 and AUA](https://github.com/eembc/coremark/blob/main/LICENSE.md) | Apache for code, trademark use restricted by AUA |
+| benchmark-dhrystone | [via SiFive, no license](https://github.com/sifive/benchmark-dhrystone/blob/master/LICENSE?tab=License-1-ov-file) | Code is many decades old and re-shared by SiFive, No explicit license  |
 
 Note on CoreMark: The software is under Apache 2.0, but the "CoreMark" trademark and name usage is restricted by the Acceptable Use Agreement (AUA). Do not use the name in modified benchmarks or without compliance.
 

--- a/bare-metal/README.md
+++ b/bare-metal/README.md
@@ -45,20 +45,27 @@ xsdb%
 ```
 Alternatively, you can call the script `../scripts/debugger_download_load_program.sh`
 
-## "Coremark" CPU benchmarking program
+## "Coremark" and "Dhrystone" CPU benchmarking programs
 
-Compiles same way as "Hello World" program but from within `bare-metal/coremark` .
+These compile same way as "Hello World" program but from within `bare-metal/coremark` or `bare-metal/dhrystone` .
 
-Also runs on any 64-bit or 32-bit Rocket flavor.
+These also run on any 64-bit or 32-bit Rocket flavor.
 
-There are two parameters you can adjust.
+There are two parameters you can adjust per program.
 
-Within `bare-metal/coremark/Makefile`:
+For both programs, within `bare-metal/common.mk` :
+
+`FPGA_CPU_CLK_FREQ`: defaults to 100MHz, but set this to whatever frequency you're clocking your CPU .
+
+And then program-specfic iterations. First for Coremark, within `bare-metal/coremark/Makefile`:
 
 `ITERATIONS`: 5000 by default, which should be sufficient for all permutations of RocketConfig + Board + ClkFreq.
 
 Coremark requires runtime > 10 secs, so increase ITERATIONS if your CPU is somehow too fast.
 
-And then within `bare-metal/common.mk` :
+Secondly, for Dhrystone, within `bare-metal/dhrystone/Makefile`:
 
-`FPGA_CPU_CLK_FREQ`: defaults to 100MHz, but set this to whatever frequency you're clocking your CPU
+`DHRY_ITERS`: 3000000 by default, which should be sufficient for all permutations of RocketConfig + Board + ClkFreq.
+
+Best not to decrease this too much, as Dhrystone won't print a result if it deems the runtime wasn't long enough.
+

--- a/bare-metal/common/include/fpu.h
+++ b/bare-metal/common/include/fpu.h
@@ -1,12 +1,6 @@
 #ifndef FPU_H
 #define FPU_H
 
-// necessary for enabling the FPU in baremetal
-static inline void enable_fpu() {
-    uint64_t mstatus;
-    asm volatile ("csrr %0, mstatus" : "=r"(mstatus));
-    mstatus |= (1 << 13); // FS = 01 (Initial)
-    asm volatile ("csrw mstatus, %0" :: "r"(mstatus));
-}
+extern void enable_fpu();
 
 #endif

--- a/bare-metal/common/src/fpu.c
+++ b/bare-metal/common/src/fpu.c
@@ -1,0 +1,11 @@
+#include <fpu.h>
+#include <stdint.h>
+
+// necessary for enabling the FPU in baremetal
+void enable_fpu() {
+    uint64_t mstatus;
+    asm volatile ("csrr %0, mstatus" : "=r"(mstatus));
+    mstatus |= (1 << 13); // FS = 01 (Initial)
+    asm volatile ("csrw mstatus, %0" :: "r"(mstatus));
+}
+

--- a/bare-metal/common/src/heap.c
+++ b/bare-metal/common/src/heap.c
@@ -1,0 +1,25 @@
+#include <stddef.h>
+
+// These are declared weakly in newlib, but we'll override them entirely
+extern void* _sbrk(ptrdiff_t increment);
+
+void* malloc(size_t size) {
+    void *ptr = _sbrk(size);
+    return (ptr == (void*)-1) ? NULL : ptr;
+}
+
+void free(void *ptr) {
+    // No-op: simple bump allocator can't free
+}
+
+extern char _end; // defined by linker
+static char *heap_end;
+
+void* _sbrk(ptrdiff_t incr) {
+    if (!heap_end)
+        heap_end = &_end;
+
+    char *prev_heap_end = heap_end;
+    heap_end += incr;
+    return (void *)prev_heap_end;
+}

--- a/bare-metal/common/src/main.lds
+++ b/bare-metal/common/src/main.lds
@@ -39,6 +39,7 @@ SECTIONS {
     *(.bss .bss.* .gnu.linkonce.b.*)
     . = ALIGN(8);
     PROVIDE(_ebss = .);
+    PROVIDE(_end = .);  /* Required for _sbrk */
   } >memory_mem
 
   .note (INFO) : {

--- a/bare-metal/dhrystone/Makefile
+++ b/bare-metal/dhrystone/Makefile
@@ -1,0 +1,12 @@
+OPTIMIZATION = -O3
+INCLUDE_DIR = ./benchmark-dhrystone
+
+# define desired dhrystone iterations
+# NOTE: this needs to be a large number to make dhrystone happy enough for an accurate result
+DHRY_ITERS = 3000000
+
+TEST_SPECIFIC_FLAGS = -DDHRY_ITERS=$(DHRY_ITERS) -Dprintf=kprintf -DMSC_CLOCK
+
+SRCS = head.S benchmark-dhrystone/dhry_1.c benchmark-dhrystone/dhry_2.c time_override.c
+
+include ../common.mk

--- a/bare-metal/dhrystone/head.S
+++ b/bare-metal/dhrystone/head.S
@@ -1,0 +1,11 @@
+#include "common.h"
+
+.section .text.start, "ax", @progbits
+.globl _start
+_start:
+  li sp, BOOT_MEM_END
+  call enable_fpu
+  call main
+_hang:
+  wfi
+  j _hang

--- a/bare-metal/dhrystone/time_override.c
+++ b/bare-metal/dhrystone/time_override.c
@@ -1,0 +1,11 @@
+#include <time.h>
+#include <timer.h>
+#include <stdint.h>
+
+extern uint32_t read_mcycle();
+
+clock_t clock() {
+    uint32_t cycles = read_mcycle();
+    clock_t mics = cycles / FPGA_CPU_CLK_FREQ;
+    return mics;
+}


### PR DESCRIPTION
In the same vein as Coremark, adding Dhrystone benchmark to baremetal. Dhrystone is very old and isn't actively owned or maintained by anyone, but it's re-shared by several sources on Github. Among these sources, I figured SiFive was a good choice since the repo here already pulls in other SiFive repos.