### PR TITLE
Add Alveo X3522PV board (speedgrade-3 UltraScale+)

### DIFF
--- a/board/rocket-freq
+++ b/board/rocket-freq
@@ -22,6 +22,15 @@ vc707         Rocket.*          100.0
 (vcu1525|u200|u250)          Rocket.*m2            100.0
 (vcu1525|u200|u250)          Rocket.*              125.0
 
+(x3522pv)          Rocket32s1            250.0
+(x3522pv)          Rocket64w1            160.0
+(x3522pv)          Rocket64b1            230.76923
+(x3522pv)          Rocket64.*gem.*       31.25
+(x3522pv)          Rocket64[xyz].*       40.0
+(x3522pv)          Rocket.*b[2-9][0-9].* 62.5
+(x3522pv)          Rocket.*b1[0-9].*     80.0
+(x3522pv)          Rocket.*              125.0
+
 .*            Rocket.*gem.*     20.0
 .*            Rocket64[xyz].*   20.0
 .*            Rocket.*l2w?      31.25

--- a/board/x3522pv/Makefile.inc
+++ b/board/x3522pv/Makefile.inc
@@ -1,0 +1,14 @@
+BOARD_PART  ?= NONE
+XILINX_PART ?= xcux35-vsva1365-3-e
+CFG_DEVICE  ?= SPIx4 -size 256
+CFG_PART    ?= mt25qu02g-spi-x1_x2_x4
+CFG_BOOT    ?= -loaddata {up 0x07000000 workspace/boot.elf}
+ROOTFS      ?= NFS
+
+ifneq ($(filter %m4,$(CONFIG)),)
+MEMORY_SIZE ?= 0x1000000000
+else ifneq ($(filter %m2,$(CONFIG)),)
+MEMORY_SIZE ?= 0x800000000
+else
+MEMORY_SIZE ?= 0x400000000
+endif

--- a/board/x3522pv/bootrom.c
+++ b/board/x3522pv/bootrom.c
@@ -1,0 +1,22 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "common.h"
+#include "kprintf.h"
+
+// Does nothing, waits for JTAG debugger.
+
+extern unsigned char _fbss[];
+extern unsigned char _ebss[];
+
+int main(void) {
+    uint64_t * bss = (uint64_t *)_fbss;
+    while (bss < (uint64_t *)_ebss) *bss++ = 0;
+
+    kprintf("\nRISC-V %d, Boot ROM: JTAG\n", __riscv_xlen);
+    while (1) {
+        asm volatile ("wfi");
+    }
+
+    return 0;
+}

--- a/board/x3522pv/bootrom.dts
+++ b/board/x3522pv/bootrom.dts
@@ -1,0 +1,35 @@
+/ {
+
+    aliases {
+        serial0 = &uart0;
+    };
+
+    chosen {
+        stdout-path = "serial0";
+    };
+
+    io-bus {
+        #address-cells = <1>;
+        #size-cells = <1>;
+        compatible = "rocketchip-vivado-io", "simple-bus";
+        ranges;
+
+        uart0: uart@60010000 {
+            compatible = "riscv,axi-uart-1.0";
+            reg = <0x60010000 0x10000>;
+            interrupt-parent = <&{/soc/interrupt-controller@c000000}>;
+            interrupts = <1>;
+            port-number = <0>;
+        };
+
+        eth: eth0@60020000 {
+            compatible = "riscv,axi-ethernet-1.0";
+            reg = <0x60020000 0x10000>;
+            phy-mode = "10gbase-r";
+            local-mac-address = [00 0a 35 00 00 03];
+            interrupt-parent = <&{/soc/interrupt-controller@c000000}>;
+            interrupts = <3>;
+        };
+
+    };
+};

--- a/board/x3522pv/bootrom.inc
+++ b/board/x3522pv/bootrom.inc
@@ -1,0 +1,4 @@
+# X3522PV does not have SD card slot
+
+%.elf: $(dtb) head.S kprintf.c ../board/$(BOARD)/bootrom.c
+	$(CC) $(CCFLAGS) -DDEVICE_TREE='"$(dtb)"' $(LFLAGS) -o $@ head.S kprintf.c ../board/$(BOARD)/bootrom.c

--- a/board/x3522pv/ethernet-x3522pv.tcl
+++ b/board/x3522pv/ethernet-x3522pv.tcl
@@ -1,0 +1,67 @@
+set files [list \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_mac_10g.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_mac_10g_fifo.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_tx.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_if.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_tx_if.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_ber_mon.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_frame_sync.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/eth_phy_10g_rx_watchdog.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_rx_32.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_rx_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_tx_32.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/axis_xgmii_tx_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/xgmii_baser_dec_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/xgmii_baser_enc_64.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/sync_reset.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_adapter.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_async_fifo.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/lib/axis/rtl/axis_async_fifo_adapter.v"] \
+  [file normalize "../../ethernet/verilog-ethernet/rtl/lfsr.v"] \
+  [file normalize "../../ethernet/ethernet-sfp-10g.v"] \
+  [file normalize "../../ethernet/ethernet.v"] \
+]
+add_files -norecurse -fileset $source_fileset $files
+
+if { [string match "Rocket*m4" $rocket_module_name] } {
+  # Four channel memory interface
+  set block_design_tcl "m4/$block_design_tcl"
+  add_files -norecurse -fileset $source_fileset [file normalize "../../board/${vivado_board_name}/m4/riscv_wrapper.v"]
+} elseif { [string match "Rocket*m2" $rocket_module_name] } {
+  # Two channel memory interface
+  set block_design_tcl "m2/$block_design_tcl"
+  add_files -norecurse -fileset $source_fileset [file normalize "../../board/${vivado_board_name}/m2/riscv_wrapper.v"]
+} else {
+  add_files -norecurse -fileset $source_fileset [file normalize "../../board/${vivado_board_name}/riscv_wrapper.v"]
+}
+
+set files [list \
+  [file normalize ../../board/${vivado_board_name}/ethernet.xdc] \
+  [file normalize ../../ethernet/verilog-ethernet/lib/axis/syn/vivado/sync_reset.tcl] \
+  [file normalize ../../ethernet/verilog-ethernet/lib/axis/syn/vivado/axis_async_fifo.tcl] \
+  [file normalize ../../ethernet/verilog-ethernet/syn/vivado/eth_mac_fifo.tcl] \
+]
+add_files -norecurse -fileset $constraint_fileset $files
+
+create_ip -name gtwizard_ultrascale -vendor xilinx.com -library ip -module_name gtwizard_ultrascale_0
+
+set_property -dict [list CONFIG.preset {GTY-10GBASE-R}] [get_ips gtwizard_ultrascale_0]
+
+set_property -dict [list \
+    CONFIG.CHANNEL_ENABLE {X0Y28} \
+    CONFIG.TX_MASTER_CHANNEL {X0Y28} \
+    CONFIG.RX_MASTER_CHANNEL {X0Y28} \
+    CONFIG.TX_LINE_RATE {10.3125} \
+    CONFIG.TX_REFCLK_FREQUENCY {161.1328125} \
+    CONFIG.TX_USER_DATA_WIDTH {64} \
+    CONFIG.TX_INT_DATA_WIDTH {64} \
+    CONFIG.RX_LINE_RATE {10.3125} \
+    CONFIG.RX_REFCLK_FREQUENCY {161.1328125} \
+    CONFIG.RX_USER_DATA_WIDTH {64} \
+    CONFIG.RX_INT_DATA_WIDTH {64} \
+    CONFIG.RX_REFCLK_SOURCE {X0Y28 clk1} \
+    CONFIG.TX_REFCLK_SOURCE {X0Y28 clk1} \
+    CONFIG.FREERUN_FREQUENCY {125} \
+] [get_ips gtwizard_ultrascale_0]

--- a/board/x3522pv/ethernet.xdc
+++ b/board/x3522pv/ethernet.xdc
@@ -1,0 +1,10 @@
+# QSFP28 Interfaces
+set_property -dict {LOC K4 } [get_ports qsfp0_rx1_p] ;
+set_property -dict {LOC K3 } [get_ports qsfp0_rx1_n] ;
+set_property -dict {LOC J7 } [get_ports qsfp0_tx1_p] ;
+set_property -dict {LOC J6 } [get_ports qsfp0_tx1_n] ;
+set_property -dict {LOC P9 } [get_ports qsfp0_mgt_refclk_1_p] ;
+set_property -dict {LOC P8 } [get_ports qsfp0_mgt_refclk_1_n] ;
+
+# 161.1328125 MHz MGT reference clock
+create_clock -period 6.206 -name qsfp0_mgt_refclk_1 [get_ports qsfp0_mgt_refclk_1_p]

--- a/board/x3522pv/riscv-2024.1.tcl
+++ b/board/x3522pv/riscv-2024.1.tcl
@@ -1,0 +1,681 @@
+
+################################################################
+# This is a generated script based on design: riscv
+#
+# Though there are limitations about the generated script,
+# the main purpose of this utility is to make learning
+# IP Integrator Tcl commands easier.
+################################################################
+
+namespace eval _tcl {
+proc get_script_folder {} {
+   set script_path [file normalize [info script]]
+   set script_folder [file dirname $script_path]
+   return $script_folder
+}
+}
+variable script_folder
+set script_folder [_tcl::get_script_folder]
+
+################################################################
+# Check if script is running in correct Vivado version.
+################################################################
+set scripts_vivado_version 2024.1
+set current_vivado_version [version -short]
+
+if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
+   puts ""
+   catch {common::send_gid_msg -ssname BD::TCL -id 2041 -severity "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
+
+   return 1
+}
+
+################################################################
+# START
+################################################################
+
+# To test this script, run the following commands from Vivado Tcl console:
+# source riscv_script.tcl
+
+
+# The design that will be created by this Tcl script contains the following
+# module references:
+# $rocket_module_name, uart, ethernet
+
+# Please add the sources of those modules before sourcing this Tcl script.
+
+# If there is no project opened, this script will create a
+# project, but make sure you do not have an existing project
+# <./myproj/project_1.xpr> in the current working folder.
+
+set list_projs [get_projects -quiet]
+if { $list_projs eq "" } {
+   create_project project_1 myproj -part xcux35-vsva1365-3-e
+}
+
+
+# CHANGE DESIGN NAME HERE
+variable design_name
+set design_name riscv
+
+# If you do not already have an existing IP Integrator design open,
+# you can create a design using the following command:
+#    create_bd_design $design_name
+
+# Creating design if needed
+set errMsg ""
+set nRet 0
+
+set cur_design [current_bd_design -quiet]
+set list_cells [get_bd_cells -quiet]
+
+if { ${design_name} eq "" } {
+   # USE CASES:
+   #    1) Design_name not set
+
+   set errMsg "Please set the variable <design_name> to a non-empty value."
+   set nRet 1
+
+} elseif { ${cur_design} ne "" && ${list_cells} eq "" } {
+   # USE CASES:
+   #    2): Current design opened AND is empty AND names same.
+   #    3): Current design opened AND is empty AND names diff; design_name NOT in project.
+   #    4): Current design opened AND is empty AND names diff; design_name exists in project.
+
+   if { $cur_design ne $design_name } {
+      common::send_gid_msg -ssname BD::TCL -id 2001 -severity "INFO" "Changing value of <design_name> from <$design_name> to <$cur_design> since current design is empty."
+      set design_name [get_property NAME $cur_design]
+   }
+   common::send_gid_msg -ssname BD::TCL -id 2002 -severity "INFO" "Constructing design in IPI design <$cur_design>..."
+
+} elseif { ${cur_design} ne "" && $list_cells ne "" && $cur_design eq $design_name } {
+   # USE CASES:
+   #    5) Current design opened AND has components AND same names.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 1
+} elseif { [get_files -quiet ${design_name}.bd] ne "" } {
+   # USE CASES:
+   #    6) Current opened design, has components, but diff names, design_name exists in project.
+   #    7) No opened design, design_name exists in project.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 2
+
+} else {
+   # USE CASES:
+   #    8) No opened design, design_name not in project.
+   #    9) Current opened design, has components, but diff names, design_name not in project.
+
+   common::send_gid_msg -ssname BD::TCL -id 2003 -severity "INFO" "Currently there is no design <$design_name> in project, so creating one..."
+
+   create_bd_design $design_name
+
+   common::send_gid_msg -ssname BD::TCL -id 2004 -severity "INFO" "Making design <$design_name> as current_bd_design."
+   current_bd_design $design_name
+
+}
+
+common::send_gid_msg -ssname BD::TCL -id 2005 -severity "INFO" "Currently the variable <design_name> is equal to \"$design_name\"."
+
+if { $nRet != 0 } {
+   catch {common::send_gid_msg -ssname BD::TCL -id 2006 -severity "ERROR" $errMsg}
+   return $nRet
+}
+
+set bCheckIPsPassed 1
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\
+xilinx.com:ip:clk_wiz:6.0\
+xilinx.com:ip:util_vector_logic:2.0\
+xilinx.com:ip:ddr4:2.2\
+xilinx.com:ip:smartconnect:1.0\
+xilinx.com:ip:xdma:4.1\
+xilinx.com:ip:util_ds_buf:2.2\
+xilinx.com:ip:xlconcat:2.1\
+xilinx.com:ip:xlconstant:1.1\
+"
+
+   set list_ips_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+   if { $list_ips_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2012 -severity "ERROR" "The following IPs are not found in the IP Catalog:\n  $list_ips_missing\n\nResolution: Please add the repository containing the IP(s) to the project." }
+      set bCheckIPsPassed 0
+   }
+
+}
+
+##################################################################
+# CHECK Modules
+##################################################################
+set bCheckModules 1
+if { $bCheckModules == 1 } {
+   set list_check_mods "\
+$rocket_module_name\
+ethernet\
+uart\
+"
+
+   set list_mods_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2020 -severity "INFO" "Checking if the following modules exist in the project's sources: $list_check_mods ."
+
+   foreach mod_vlnv $list_check_mods {
+      if { [can_resolve_reference $mod_vlnv] == 0 } {
+         lappend list_mods_missing $mod_vlnv
+      }
+   }
+
+   if { $list_mods_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2021 -severity "ERROR" "The following module(s) are not found in the project: $list_mods_missing" }
+      common::send_gid_msg -ssname BD::TCL -id 2022 -severity "INFO" "Please add source files for the missing module(s) above."
+      set bCheckIPsPassed 0
+   }
+}
+
+if { $bCheckIPsPassed != 1 } {
+  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
+  return 3
+}
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+# Hierarchical cell: IO
+proc create_hier_cell_IO { parentCell nameHier } {
+
+  variable script_folder
+
+  if { $parentCell eq "" || $nameHier eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2092 -severity "ERROR" "create_hier_cell_IO() - Empty argument(s)!"}
+     return
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+  # Create cell and set as current instance
+  set hier_obj [create_bd_cell -type hier $nameHier]
+  current_bd_instance $hier_obj
+
+  # Create interface pins
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 M00_AXI
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 M01_AXI
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S01_AXI
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:axis_rtl:1.0 eth_rx_axis
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 eth_tx_axis
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:pcie_7x_mgt_rtl:1.0 pci_express_x16
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 pcie_refclk
+
+
+  # Create pins
+  create_bd_pin -dir I -type clk axi_clock
+  create_bd_pin -dir I -type rst axi_reset
+  create_bd_pin -dir I -type clk clock100MHz
+  create_bd_pin -dir I -type clk eth_gt_user_clock
+  create_bd_pin -dir I -from 15 -to 0 eth_status
+  create_bd_pin -dir O -from 7 -to 0 interrupts
+  create_bd_pin -dir I -type rst pcie_perstn
+  create_bd_pin -dir I -type clk sdram_clock
+  create_bd_pin -dir I usb_uart_rxd
+  create_bd_pin -dir O usb_uart_txd
+  create_bd_pin -dir O user_lnk_up
+
+  # Create instance: UART, and set properties
+  set block_name uart
+  set block_cell_name UART
+  if { [catch {set UART [create_bd_cell -type module -reference $block_name $block_cell_name] } errmsg] } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2095 -severity "ERROR" "Unable to add referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   } elseif { $UART eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2096 -severity "ERROR" "Unable to referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   }
+
+  # Create instance: Ethernet, and set properties
+  set block_name ethernet
+  set block_cell_name Ethernet
+  if { [catch {set Ethernet [create_bd_cell -type module -reference $block_name $block_cell_name] } errmsg] } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2095 -severity "ERROR" "Unable to add referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   } elseif { $Ethernet eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2096 -severity "ERROR" "Unable to referenced block <$block_name>. Please add the files for ${block_name}'s definition into the project."}
+     return 1
+   }
+    set_property -dict [ list \
+   CONFIG.axis_word_bits {64} \
+   CONFIG.burst_size {64} \
+   CONFIG.dma_word_bits {64} \
+   CONFIG.enable_mdio {0} \
+ ] $Ethernet
+
+
+  # Create instance: xdma_0, and set properties
+  set xdma_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xdma:4.1 xdma_0 ]
+  set_property -dict [list \
+    CONFIG.axil_master_64bit_en {true} \
+    CONFIG.axilite_master_en {true} \
+    CONFIG.axilite_master_size {4} \
+    CONFIG.axist_bypass_en {false} \
+    CONFIG.en_gt_selection {true} \
+    CONFIG.mode_selection {Advanced} \
+    CONFIG.pcie_blk_locn {PCIE4C_X0Y0} \
+    CONFIG.pf0_msi_enabled {false} \
+    CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+    CONFIG.pl_link_cap_max_link_width {X8} \
+    CONFIG.select_quad {GTY_Quad_225} \
+    CONFIG.xdma_axilite_slave {false} \
+    CONFIG.xdma_pcie_64bit_en {true} \
+  ] $xdma_0
+  # Create instance: smartconnect_0, and set properties
+  set smartconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_0 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {5} \
+   CONFIG.NUM_MI {4} \
+   CONFIG.NUM_SI {2} \
+ ] $smartconnect_0
+
+  # Create instance: smartconnect_2, and set properties
+  set smartconnect_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_2 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {3} \
+   CONFIG.NUM_SI {2} \
+ ] $smartconnect_2
+
+  # Create instance: util_ds_buf, and set properties
+  set util_ds_buf [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_ds_buf:2.2 util_ds_buf ]
+  set_property -dict [ list \
+   CONFIG.C_BUF_TYPE {IBUFDSGTE} \
+   CONFIG.DIFF_CLK_IN_BOARD_INTERFACE {Custom} \
+   CONFIG.USE_BOARD_FLOW {true} \
+ ] $util_ds_buf
+
+  # Create instance: xlconcat_0, and set properties
+  set xlconcat_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 xlconcat_0 ]
+  set_property -dict [ list \
+   CONFIG.NUM_PORTS {8} \
+ ] $xlconcat_0
+
+  # Create instance: xlconstant_0, and set properties
+  set xlconstant_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_0 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+   CONFIG.CONST_WIDTH {1} \
+ ] $xlconstant_0
+
+
+  # Create instance: xlconstant_2, and set properties
+  set xlconstant_2 [ create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 xlconstant_2 ]
+  set_property -dict [ list \
+   CONFIG.CONST_VAL {0} \
+ ] $xlconstant_2
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net Conn1 [get_bd_intf_pins pcie_refclk] [get_bd_intf_pins util_ds_buf/CLK_IN_D]
+  connect_bd_intf_net -intf_net Conn2 [get_bd_intf_pins eth_tx_axis] [get_bd_intf_pins Ethernet/TX_AXIS]
+  connect_bd_intf_net -intf_net Conn3 [get_bd_intf_pins eth_rx_axis] [get_bd_intf_pins Ethernet/RX_AXIS]
+  connect_bd_intf_net -intf_net RocketChip_IO_AXI4 [get_bd_intf_pins S01_AXI] [get_bd_intf_pins smartconnect_0/S01_AXI]
+  connect_bd_intf_net -intf_net Ethernet_M_AXI [get_bd_intf_pins Ethernet/M_AXI] [get_bd_intf_pins smartconnect_2/S01_AXI]
+  connect_bd_intf_net -intf_net xdma_0_M_AXI [get_bd_intf_pins xdma_0/M_AXI] [get_bd_intf_pins smartconnect_2/S00_AXI]
+  connect_bd_intf_net -intf_net xdma_0_M_AXI_LITE [get_bd_intf_pins xdma_0/M_AXI_LITE] [get_bd_intf_pins smartconnect_0/S00_AXI]
+  connect_bd_intf_net -intf_net xdma_0_pcie_mgt [get_bd_intf_pins pci_express_x16] [get_bd_intf_pins xdma_0/pcie_mgt]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins M01_AXI] [get_bd_intf_pins smartconnect_0/M01_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M02_AXI [get_bd_intf_pins UART/S_AXI_LITE] [get_bd_intf_pins smartconnect_0/M02_AXI]
+  connect_bd_intf_net -intf_net smartconnect_0_M03_AXI [get_bd_intf_pins Ethernet/S_AXI_LITE] [get_bd_intf_pins smartconnect_0/M03_AXI]
+  connect_bd_intf_net -intf_net smartconnect_2_M00_AXI [get_bd_intf_pins M00_AXI] [get_bd_intf_pins smartconnect_2/M00_AXI]
+
+  # Create port connections
+  connect_bd_net -net DDR_clock [get_bd_pins sdram_clock] [get_bd_pins smartconnect_0/aclk1]
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins axi_reset] [get_bd_pins UART/async_resetn] [get_bd_pins Ethernet/async_resetn] [get_bd_pins smartconnect_0/aresetn] [get_bd_pins smartconnect_2/aresetn]
+  connect_bd_net -net RocketChip_clock [get_bd_pins axi_clock] [get_bd_pins smartconnect_0/aclk2] [get_bd_pins smartconnect_2/aclk1]
+  connect_bd_net -net clock100MHz [get_bd_pins clock100MHz] [get_bd_pins UART/clock] [get_bd_pins smartconnect_0/aclk3]
+  connect_bd_net -net eth_gt_user_clock_1 [get_bd_pins eth_gt_user_clock] [get_bd_pins Ethernet/clock] [get_bd_pins smartconnect_0/aclk4] [get_bd_pins smartconnect_2/aclk2]
+  connect_bd_net -net Ethernet_interrupt [get_bd_pins Ethernet/interrupt] [get_bd_pins xlconcat_0/In2]
+  connect_bd_net -net interrupts [get_bd_pins interrupts] [get_bd_pins xlconcat_0/dout]
+  connect_bd_net -net pcie_perstn [get_bd_pins pcie_perstn] [get_bd_pins xdma_0/sys_rst_n]
+  connect_bd_net -net xdma_0_axi_aclk [get_bd_pins xdma_0/axi_aclk] [get_bd_pins smartconnect_0/aclk] [get_bd_pins smartconnect_2/aclk]
+
+  connect_bd_net -net xdma_0_user_lnk_up [get_bd_pins xdma_0/user_lnk_up] [get_bd_pins user_lnk_up]
+  connect_bd_net -net status_vector_0_1 [get_bd_pins eth_status] [get_bd_pins Ethernet/status_vector]
+  connect_bd_net -net uart_0_interrupt [get_bd_pins UART/interrupt] [get_bd_pins xlconcat_0/In0]
+  connect_bd_net -net usb_uart_rxd [get_bd_pins usb_uart_rxd] [get_bd_pins UART/RxD]
+  connect_bd_net -net usb_uart_txd [get_bd_pins usb_uart_txd] [get_bd_pins UART/TxD]
+  connect_bd_net -net util_ds_buf_IBUF_DS_ODIV2 [get_bd_pins xdma_0/sys_clk] [get_bd_pins util_ds_buf/IBUF_DS_ODIV2]
+  connect_bd_net -net util_ds_buf_IBUF_OUT [get_bd_pins xdma_0/sys_clk_gt] [get_bd_pins util_ds_buf/IBUF_OUT]
+  connect_bd_net -net xlconstant_0_dout [get_bd_pins Ethernet/mdio_int] [get_bd_pins xlconcat_0/In1] [get_bd_pins xlconcat_0/In4] [get_bd_pins xlconcat_0/In5] [get_bd_pins xlconcat_0/In6] [get_bd_pins xlconcat_0/In7] [get_bd_pins xlconstant_0/dout]
+  connect_bd_net -net xlconstant_2_dout [get_bd_pins UART/CTSn] [get_bd_pins xlconstant_2/dout]
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+}
+
+# Hierarchical cell: DDR
+proc create_hier_cell_DDR { parentCell nameHier } {
+
+  variable script_folder
+
+  if { $parentCell eq "" || $nameHier eq "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2092 -severity "ERROR" "create_hier_cell_DDR() - Empty argument(s)!"}
+     return
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+  # Create cell and set as current instance
+  set hier_obj [create_bd_cell -type hier $nameHier]
+  current_bd_instance $hier_obj
+
+  # Create interface pins
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 C0_DDR4_S_AXI_CTRL
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S00_AXI
+
+  create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram_c0
+
+  create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_300mhz_clk0
+
+
+  # Create pins
+  create_bd_pin -dir I axi_clock
+  create_bd_pin -dir I axi_reset
+  create_bd_pin -dir O -type clk c0_ddr4_ui_clk
+  create_bd_pin -dir O c0_init_calib_complete
+  create_bd_pin -dir I -type rst sys_reset
+
+  # Create instance: ddr4_0, and set properties
+  set ddr4_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:ddr4:2.2 ddr4_0 ]
+  set_property -dict [list \
+    CONFIG.ADDN_UI_CLKOUT1_FREQ_HZ {None} \
+    CONFIG.C0.DDR4_AxiAddressWidth {33} \
+    CONFIG.C0.DDR4_AxiDataWidth {512} \
+    CONFIG.C0.DDR4_AxiIDWidth {4} \
+    CONFIG.C0.DDR4_CasLatency {19} \
+    CONFIG.C0.DDR4_CasWriteLatency {14} \
+    CONFIG.C0.DDR4_DataMask {NO_DM_NO_DBI} \
+    CONFIG.C0.DDR4_DataWidth {72} \
+    CONFIG.C0.DDR4_EN_PARITY {false} \
+    CONFIG.C0.DDR4_InputClockPeriod {3334} \
+    CONFIG.C0.DDR4_MemoryPart {MT40A1G16RC-062E} \
+    CONFIG.C0.DDR4_MemoryType {Components} \
+    CONFIG.C0.DDR4_TimePeriod {750} \
+    CONFIG.C0_CLOCK_BOARD_INTERFACE {Custom} \
+    CONFIG.C0_DDR4_BOARD_INTERFACE {Custom} \
+  ] $ddr4_0
+
+
+  # Create instance: smartconnect_1, and set properties
+  set smartconnect_1 [ create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_1 ]
+  set_property -dict [ list \
+   CONFIG.NUM_CLKS {2} \
+   CONFIG.NUM_SI {1} \
+ ] $smartconnect_1
+
+  # Create instance: util_vector_logic_0, and set properties
+  set util_vector_logic_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 util_vector_logic_0 ]
+  set_property -dict [ list \
+   CONFIG.C_OPERATION {not} \
+   CONFIG.C_SIZE {1} \
+   CONFIG.LOGO_FILE {data/sym_notgate.png} \
+ ] $util_vector_logic_0
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net RocketChip_MEM_AXI4 [get_bd_intf_pins S00_AXI] [get_bd_intf_pins smartconnect_1/S00_AXI]
+  connect_bd_intf_net -intf_net ddr4_0_C0_DDR4 [get_bd_intf_pins ddr4_sdram_c0] [get_bd_intf_pins ddr4_0/C0_DDR4]
+  connect_bd_intf_net -intf_net default_300mhz_clk0_1 [get_bd_intf_pins default_300mhz_clk0] [get_bd_intf_pins ddr4_0/C0_SYS_CLK]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins C0_DDR4_S_AXI_CTRL] [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI_CTRL]
+  connect_bd_intf_net -intf_net smartconnect_1_M00_AXI [get_bd_intf_pins ddr4_0/C0_DDR4_S_AXI] [get_bd_intf_pins smartconnect_1/M00_AXI]
+
+  # Create port connections
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins axi_reset] [get_bd_pins smartconnect_1/aresetn]
+  connect_bd_net -net axi_clock [get_bd_pins axi_clock] [get_bd_pins smartconnect_1/aclk]
+  connect_bd_net -net ddr4_0_c0_ddr4_ui_clk [get_bd_pins c0_ddr4_ui_clk] [get_bd_pins ddr4_0/c0_ddr4_ui_clk] [get_bd_pins smartconnect_1/aclk1]
+  connect_bd_net -net ddr4_0_c0_ddr4_ui_clk_sync_rst [get_bd_pins ddr4_0/c0_ddr4_ui_clk_sync_rst] [get_bd_pins util_vector_logic_0/Op1]
+  connect_bd_net -net ddr4_0_c0_init_calib_complete [get_bd_pins c0_init_calib_complete] [get_bd_pins ddr4_0/c0_init_calib_complete]
+  connect_bd_net -net resetn_inv_0_Res [get_bd_pins sys_reset] [get_bd_pins ddr4_0/sys_rst]
+  connect_bd_net -net c0_ddr4_aresetn [get_bd_pins ddr4_0/c0_ddr4_aresetn] [get_bd_pins util_vector_logic_0/Res]
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+}
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+  set clk_user [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 clk_user ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {300000000} \
+   ] $clk_user
+
+  set ddr4_sdram_c0 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:ddr4_rtl:1.0 ddr4_sdram_c0 ]
+
+  set default_300mhz_clk0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 default_300mhz_clk0 ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {300000000} \
+   ] $default_300mhz_clk0
+
+  set eth_rx_axis [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:axis_rtl:1.0 eth_rx_axis ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   CONFIG.HAS_TKEEP {1} \
+   CONFIG.HAS_TLAST {1} \
+   CONFIG.HAS_TREADY {1} \
+   CONFIG.HAS_TSTRB {0} \
+   CONFIG.LAYERED_METADATA {undef} \
+   CONFIG.TDATA_NUM_BYTES {8} \
+   CONFIG.TDEST_WIDTH {0} \
+   CONFIG.TID_WIDTH {0} \
+   CONFIG.TUSER_WIDTH {1} \
+   ] $eth_rx_axis
+
+  set eth_tx_axis [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:axis_rtl:1.0 eth_tx_axis ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   ] $eth_tx_axis
+
+  set pci_express_x16 [ create_bd_intf_port -mode Master -vlnv xilinx.com:interface:pcie_7x_mgt_rtl:1.0 pci_express_x16 ]
+
+  set pcie_refclk [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 pcie_refclk ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {100000000} \
+   ] $pcie_refclk
+
+
+  # Create ports
+  set eth_clock [ create_bd_port -dir O -type clk eth_clock ]
+  set eth_clock_ok [ create_bd_port -dir O -type rst eth_clock_ok ]
+  set eth_gt_user_clock [ create_bd_port -dir I -type clk eth_gt_user_clock ]
+  set_property -dict [ list \
+   CONFIG.FREQ_HZ {156250000} \
+   ] $eth_gt_user_clock
+  set eth_status [ create_bd_port -dir I -from 15 -to 0 eth_status ]
+  set pcie_perstn [ create_bd_port -dir I -type rst pcie_perstn ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] $pcie_perstn
+  set resetn [ create_bd_port -dir I -type rst resetn ]
+  set_property -dict [ list \
+   CONFIG.POLARITY {ACTIVE_LOW} \
+ ] $resetn
+  set usb_uart_rxd [ create_bd_port -dir I usb_uart_rxd ]
+  set usb_uart_txd [ create_bd_port -dir O usb_uart_txd ]
+
+  # Create instance: DDR
+  create_hier_cell_DDR [current_bd_instance .] DDR
+
+  # Create instance: IO
+  create_hier_cell_IO [current_bd_instance .] IO
+
+  # Create instance: RocketChip, and set properties
+  global rocket_module_name
+  set RocketChip [create_bd_cell -type module -reference $rocket_module_name RocketChip]
+
+  # Create instance: clk_wiz_0, and set properties
+  set clk_wiz_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz:6.0 clk_wiz_0 ]
+  set_property -dict [ list \
+   CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {125.0} \
+   CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {125.000} \
+   CONFIG.CLKOUT2_USED {true} \
+   CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {100.000} \
+   CONFIG.CLKOUT3_USED {true} \
+   CONFIG.NUM_OUT_CLKS {3} \
+   CONFIG.OPTIMIZE_CLOCKING_STRUCTURE_EN {true} \
+   CONFIG.PRIM_SOURCE {Differential_clock_capable_pin} \
+   CONFIG.USE_PHASE_ALIGNMENT {false} \
+   CONFIG.USE_RESET {false} \
+ ] $clk_wiz_0
+
+  # Create instance: resetn_inv_0, and set properties
+  set resetn_inv_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 resetn_inv_0 ]
+  set_property -dict [ list \
+   CONFIG.C_OPERATION {not} \
+   CONFIG.C_SIZE {1} \
+ ] $resetn_inv_0
+
+  # Create interface connections
+  connect_bd_intf_net -intf_net IO_TX_AXIS_0 [get_bd_intf_ports eth_tx_axis] [get_bd_intf_pins IO/eth_tx_axis]
+  connect_bd_intf_net -intf_net RX_AXIS_0_1 [get_bd_intf_ports eth_rx_axis] [get_bd_intf_pins IO/eth_rx_axis]
+  connect_bd_intf_net -intf_net RocketChip_IO_AXI4 [get_bd_intf_pins IO/S01_AXI] [get_bd_intf_pins RocketChip/IO_AXI4]
+  connect_bd_intf_net -intf_net RocketChip_MEM_AXI4 [get_bd_intf_pins DDR/S00_AXI] [get_bd_intf_pins RocketChip/MEM_AXI4]
+  connect_bd_intf_net -intf_net clk_user_1 [get_bd_intf_ports clk_user] [get_bd_intf_pins clk_wiz_0/CLK_IN1_D]
+  connect_bd_intf_net -intf_net ddr4_sdram_c0 [get_bd_intf_ports ddr4_sdram_c0] [get_bd_intf_pins DDR/ddr4_sdram_c0]
+  connect_bd_intf_net -intf_net default_300mhz_clk0 [get_bd_intf_ports default_300mhz_clk0] [get_bd_intf_pins DDR/default_300mhz_clk0]
+  connect_bd_intf_net -intf_net pcie_refclk [get_bd_intf_ports pcie_refclk] [get_bd_intf_pins IO/pcie_refclk]
+  connect_bd_intf_net -intf_net qdma_0_pcie_mgt [get_bd_intf_ports pci_express_x16] [get_bd_intf_pins IO/pci_express_x16]
+  connect_bd_intf_net -intf_net smartconnect_0_M01_AXI [get_bd_intf_pins DDR/C0_DDR4_S_AXI_CTRL] [get_bd_intf_pins IO/M01_AXI]
+  connect_bd_intf_net -intf_net smartconnect_2_M00_AXI [get_bd_intf_pins IO/M00_AXI] [get_bd_intf_pins RocketChip/DMA_AXI4]
+
+  # Create port connections
+  connect_bd_net -net DDR_clock [get_bd_pins DDR/c0_ddr4_ui_clk] [get_bd_pins IO/sdram_clock]
+  connect_bd_net -net RocketChip_aresetn [get_bd_pins DDR/axi_reset] [get_bd_pins IO/axi_reset] [get_bd_pins RocketChip/aresetn]
+  connect_bd_net -net RocketChip_clock [get_bd_pins DDR/axi_clock] [get_bd_pins IO/axi_clock] [get_bd_pins RocketChip/clock] [get_bd_pins clk_wiz_0/clk_out1]
+  connect_bd_net -net clk_wiz_0_clk_out2 [get_bd_ports eth_clock] [get_bd_pins clk_wiz_0/clk_out2]
+  connect_bd_net -net clk_wiz_0_locked [get_bd_ports eth_clock_ok] [get_bd_pins RocketChip/clock_ok] [get_bd_pins clk_wiz_0/locked]
+  connect_bd_net -net clock100MHz_1 [get_bd_pins IO/clock100MHz] [get_bd_pins clk_wiz_0/clk_out3]
+  connect_bd_net -net ddr4_0_c0_init_calib_complete [get_bd_pins DDR/c0_init_calib_complete] [get_bd_pins RocketChip/mem_ok]
+  connect_bd_net -net eth_gt_user_clock_0_1 [get_bd_ports eth_gt_user_clock] [get_bd_pins IO/eth_gt_user_clock]
+  connect_bd_net -net interrupts [get_bd_pins IO/interrupts] [get_bd_pins RocketChip/interrupts]
+  connect_bd_net -net pcie_perstn [get_bd_ports pcie_perstn] [get_bd_pins IO/pcie_perstn]
+  connect_bd_net -net qdma_0_user_lnk_up [get_bd_pins IO/user_lnk_up] [get_bd_pins RocketChip/io_ok]
+  connect_bd_net -net reset [get_bd_pins DDR/sys_reset] [get_bd_pins RocketChip/sys_reset] [get_bd_pins resetn_inv_0/Res]
+  connect_bd_net -net resetn [get_bd_ports resetn] [get_bd_pins resetn_inv_0/Op1]
+  connect_bd_net -net status_vector_0_1 [get_bd_ports eth_status] [get_bd_pins IO/eth_status]
+  connect_bd_net -net usb_uart_rxd [get_bd_ports usb_uart_rxd] [get_bd_pins IO/usb_uart_rxd]
+  connect_bd_net -net usb_uart_txd [get_bd_ports usb_uart_txd] [get_bd_pins IO/usb_uart_txd]
+
+  # Create address segments
+  set addr_bits [get_property CONFIG.ADDR_WIDTH [get_bd_intf_pins RocketChip/DMA_AXI4]]
+  set_property CONFIG.dma_addr_bits $addr_bits [get_bd_cells IO/Ethernet]
+
+  set addr_range [expr 1 << $addr_bits]
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces RocketChip/MEM_AXI4] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP/C0_DDR4_ADDRESS_BLOCK] -force
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces IO/Ethernet/M_AXI] [get_bd_addr_segs RocketChip/DMA_AXI4/reg0] -force
+  assign_bd_address -offset 0x00000000 -range $addr_range -target_address_space [get_bd_addr_spaces IO/xdma_0/M_AXI] [get_bd_addr_segs RocketChip/DMA_AXI4/reg0] -force
+
+  assign_bd_address -offset 0x60010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs IO/UART/S_AXI_LITE/reg0] -force
+  assign_bd_address -offset 0x60010000 -range 0x00010000 -target_address_space [get_bd_addr_spaces IO/xdma_0/M_AXI_LITE] [get_bd_addr_segs IO/UART/S_AXI_LITE/reg0] -force
+
+  assign_bd_address -offset 0x60020000 -range 0x00010000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs IO/Ethernet/S_AXI_LITE/reg0] -force
+  assign_bd_address -offset 0x60020000 -range 0x00010000 -target_address_space [get_bd_addr_spaces IO/xdma_0/M_AXI_LITE] [get_bd_addr_segs IO/Ethernet/S_AXI_LITE/reg0] -force
+
+  assign_bd_address -offset 0x60100000 -range 0x00100000 -target_address_space [get_bd_addr_spaces RocketChip/IO_AXI4] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] -force
+  assign_bd_address -offset 0x60100000 -range 0x00100000 -target_address_space [get_bd_addr_spaces IO/xdma_0/M_AXI_LITE] [get_bd_addr_segs DDR/ddr4_0/C0_DDR4_MEMORY_MAP_CTRL/C0_REG] -force
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  validate_bd_design
+  save_bd_design
+}
+# End of create_root_design()
+
+
+##################################################################
+# MAIN FLOW
+##################################################################
+
+create_root_design ""

--- a/board/x3522pv/riscv_wrapper.v
+++ b/board/x3522pv/riscv_wrapper.v
@@ -1,0 +1,148 @@
+module riscv_wrapper (
+    input wire clk_user_clk_n,
+    input wire clk_user_clk_p,
+
+    /* DDR4 */
+    output wire ddr4_sdram_c0_act_n,
+    output wire [16:0]ddr4_sdram_c0_adr,
+    output wire [1:0]ddr4_sdram_c0_ba,
+    output wire [0:0]ddr4_sdram_c0_bg,
+    output wire ddr4_sdram_c0_ck_c,
+    output wire ddr4_sdram_c0_ck_t,
+    output wire ddr4_sdram_c0_cke,
+    output wire ddr4_sdram_c0_cs_n,
+    inout  wire [71:0]ddr4_sdram_c0_dq,
+    inout  wire [8:0]ddr4_sdram_c0_dqs_c,
+    inout  wire [8:0]ddr4_sdram_c0_dqs_t,
+    inout wire [8:0] ddr4_sdram_c0_dm_n,
+    output wire ddr4_sdram_c0_odt,
+    output wire ddr4_sdram_c0_reset_n,
+    input  wire default_300mhz_clk0_clk_n,
+    input  wire default_300mhz_clk0_clk_p,
+
+    /* PCIe */
+    input  wire [7:0]pci_express_x16_rxn,
+    input  wire [7:0]pci_express_x16_rxp,
+    output wire [7:0]pci_express_x16_txn,
+    output wire [7:0]pci_express_x16_txp,
+    input  wire pcie_perstn,
+    input  wire pcie_refclk_clk_n,
+    input  wire pcie_refclk_clk_p,
+
+    /* UART */
+    input  wire usb_uart_rxd,
+    output wire usb_uart_txd,
+
+    /* QSFP28 #0 */
+    output wire         qsfp0_tx1_p,
+    output wire         qsfp0_tx1_n,
+    input  wire         qsfp0_rx1_p,
+    input  wire         qsfp0_rx1_n,
+    input  wire         qsfp0_mgt_refclk_1_p,
+    input  wire         qsfp0_mgt_refclk_1_n
+);
+
+// Ethernet phy initialization reset and clock
+wire eth_clock_ok;
+wire eth_clock;
+
+// Ethernet GT user clock
+wire eth_gt_user_clock;
+
+wire [63:0 ]eth_rx_axis_tdata;
+wire [7:0] eth_rx_axis_tkeep;
+wire eth_rx_axis_tlast;
+wire eth_rx_axis_tready;
+wire eth_rx_axis_tuser;
+wire eth_rx_axis_tvalid;
+wire [15:0] eth_status;
+wire [63:0] eth_tx_axis_tdata;
+wire [7:0] eth_tx_axis_tkeep;
+wire eth_tx_axis_tlast;
+wire eth_tx_axis_tready;
+wire eth_tx_axis_tuser;
+wire eth_tx_axis_tvalid;
+
+riscv riscv_i (
+    .clk_user_clk_n(clk_user_clk_n),
+    .clk_user_clk_p(clk_user_clk_p),
+    .ddr4_sdram_c0_act_n(ddr4_sdram_c0_act_n),
+    .ddr4_sdram_c0_adr(ddr4_sdram_c0_adr),
+    .ddr4_sdram_c0_ba(ddr4_sdram_c0_ba),
+    .ddr4_sdram_c0_bg(ddr4_sdram_c0_bg),
+    .ddr4_sdram_c0_ck_c(ddr4_sdram_c0_ck_c),
+    .ddr4_sdram_c0_ck_t(ddr4_sdram_c0_ck_t),
+    .ddr4_sdram_c0_cke(ddr4_sdram_c0_cke),
+    .ddr4_sdram_c0_cs_n(ddr4_sdram_c0_cs_n),
+    .ddr4_sdram_c0_dq(ddr4_sdram_c0_dq),
+    .ddr4_sdram_c0_dqs_c(ddr4_sdram_c0_dqs_c),
+    .ddr4_sdram_c0_dqs_t(ddr4_sdram_c0_dqs_t),
+    .ddr4_sdram_c0_odt(ddr4_sdram_c0_odt),
+    .ddr4_sdram_c0_dm_n(ddr4_sdram_c0_dm_n),
+    .ddr4_sdram_c0_reset_n(ddr4_sdram_c0_reset_n),
+    .default_300mhz_clk0_clk_n(default_300mhz_clk0_clk_n),
+    .default_300mhz_clk0_clk_p(default_300mhz_clk0_clk_p),
+    .eth_clock_ok(eth_clock_ok),
+    .eth_clock(eth_clock),
+    .eth_gt_user_clock(eth_gt_user_clock),
+    .eth_rx_axis_tdata(eth_rx_axis_tdata),
+    .eth_rx_axis_tkeep(eth_rx_axis_tkeep),
+    .eth_rx_axis_tlast(eth_rx_axis_tlast),
+    .eth_rx_axis_tready(eth_rx_axis_tready),
+    .eth_rx_axis_tuser(eth_rx_axis_tuser),
+    .eth_rx_axis_tvalid(eth_rx_axis_tvalid),
+    .eth_status(eth_status),
+    .eth_tx_axis_tdata(eth_tx_axis_tdata),
+    .eth_tx_axis_tkeep(eth_tx_axis_tkeep),
+    .eth_tx_axis_tlast(eth_tx_axis_tlast),
+    .eth_tx_axis_tready(eth_tx_axis_tready),
+    .eth_tx_axis_tuser(eth_tx_axis_tuser),
+    .eth_tx_axis_tvalid(eth_tx_axis_tvalid),
+    .pci_express_x16_rxn(pci_express_x16_rxn),
+    .pci_express_x16_rxp(pci_express_x16_rxp),
+    .pci_express_x16_txn(pci_express_x16_txn),
+    .pci_express_x16_txp(pci_express_x16_txp),
+    .pcie_perstn(pcie_perstn),
+    .pcie_refclk_clk_n(pcie_refclk_clk_n),
+    .pcie_refclk_clk_p(pcie_refclk_clk_p),
+    .resetn(1'b1),
+    .usb_uart_rxd(usb_uart_rxd),
+    .usb_uart_txd(usb_uart_txd));
+
+ethernet_sfp_10g ethernet_vcu1525_i (
+    .clock_ok(eth_clock_ok),
+    .clock(eth_clock),
+
+    .eth_gt_user_clock(eth_gt_user_clock),
+
+    /* Ethernet #0 AXI Stream */
+    .eth_rx_axis_tdata(eth_rx_axis_tdata),
+    .eth_rx_axis_tkeep(eth_rx_axis_tkeep),
+    .eth_rx_axis_tlast(eth_rx_axis_tlast),
+    .eth_rx_axis_tready(eth_rx_axis_tready),
+    .eth_rx_axis_tuser(eth_rx_axis_tuser),
+    .eth_rx_axis_tvalid(eth_rx_axis_tvalid),
+    .eth_status(eth_status),
+    .eth_tx_axis_tdata(eth_tx_axis_tdata),
+    .eth_tx_axis_tkeep(eth_tx_axis_tkeep),
+    .eth_tx_axis_tlast(eth_tx_axis_tlast),
+    .eth_tx_axis_tready(eth_tx_axis_tready),
+    .eth_tx_axis_tuser(eth_tx_axis_tuser),
+    .eth_tx_axis_tvalid(eth_tx_axis_tvalid),
+
+    /* QSFP28 #0 */
+    .sfp_tx_p(qsfp0_tx1_p),
+    .sfp_tx_n(qsfp0_tx1_n),
+    .sfp_rx_p(qsfp0_rx1_p),
+    .sfp_rx_n(qsfp0_rx1_n),
+    .sfp_mgt_refclk_p(qsfp0_mgt_refclk_1_p),
+    .sfp_mgt_refclk_n(qsfp0_mgt_refclk_1_n),
+    .sfp_modsel(qsfp0_modsell),
+    .sfp_reset(qsfp0_resetl),
+    .sfp_modprs(qsfp0_modprsl),
+    .sfp_int(qsfp0_intl),
+    .sfp_lpmode(qsfp0_lpmode),
+    .sfp_refclk_reset(qsfp0_refclk_reset),
+    .sfp_fs(qsfp0_fs));
+
+endmodule

--- a/board/x3522pv/sdc.xdc
+++ b/board/x3522pv/sdc.xdc
@@ -1,0 +1,1 @@
+# SD card not supported

--- a/board/x3522pv/top.xdc
+++ b/board/x3522pv/top.xdc
@@ -1,0 +1,298 @@
+set_property CONFIG_VOLTAGE 1.8                        [current_design]
+set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable    [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE           [current_design]
+set_property CONFIG_MODE SPIx4                         [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4           [current_design]
+set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 85.0          [current_design]
+set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES        [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup         [current_design]
+set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes       [current_design]
+
+# 300MHz User Clock
+set_property -dict {LOC AL23 IOSTANDARD LVDS} [get_ports clk_user_clk_n]
+set_property -dict {LOC AK23 IOSTANDARD LVDS} [get_ports clk_user_clk_p]
+
+# PCIe
+create_clock -name sys_clk -period 10 [get_ports pcie_refclk_clk_p]
+set_false_path -from [get_ports pcie_perstn]
+set_property PULLUP true [get_ports pcie_perstn]
+set_property IOSTANDARD LVCMOS18 [get_ports pcie_perstn]
+set_property LOC [get_package_pins -filter {PIN_FUNC =~ *_PERSTN0_65}] [get_ports pcie_perstn]
+set_property PACKAGE_PIN AK18 [get_ports pcie_perstn]
+set_property PACKAGE_PIN AL10 [get_ports {pcie_refclk_clk_p}]
+
+#################################################################################
+#
+#  DDR4 Interface
+#
+#################################################################################
+#  300MHz DDR4 Clock 
+set_property PACKAGE_PIN AN27              [get_ports "default_300mhz_clk0_clk_p"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_66_AN27
+set_property IOSTANDARD LVDS               [get_ports "default_300mhz_clk0_clk_p"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_66_AN27
+set_property PACKAGE_PIN AN28              [get_ports "default_300mhz_clk0_clk_n"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L13N_T2L_N1_GC_QBC_66_AN28
+set_property IOSTANDARD LVDS               [get_ports "default_300mhz_clk0_clk_n"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L13N_T2L_N1_GC_QBC_66_AN28
+#
+#  DDR4 Active High Output from Ultrascale+ Device to hold all External DDR4 interfaces in Self refresh.
+#                  This output disconnects the memory interface reset and holds it in active and pulls the clock enables signal on the memory interfaces.
+#
+#set_property PACKAGE_PIN AN18              [get_ports "DDR4_C0_RESET_GATE"]    ;#  Bank  65 VCCO - +1V8_SYS
+#set_property IOSTANDARD LVCMOS18           [get_ports "DDR4_C0_RESET_GATE"]    ;#  Bank  65 VCCO - +1V8_SYS
+
+#
+#  DDR4 RDIMM Controller 0, 72-bit Data Interface, x5  Components, Single Rank
+#     Banks 66, 67, 68 (1.2V)
+#     Part Number MT40A1G16KD-062E
+#
+set_property PACKAGE_PIN AM30              [get_ports "ddr4_sdram_c0_adr[0]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_66_AM30
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[0]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_66_AM30
+set_property PACKAGE_PIN AR31              [get_ports "ddr4_sdram_c0_adr[1]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_66_AR31
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[1]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_66_AR31
+set_property PACKAGE_PIN AN29              [get_ports "ddr4_sdram_c0_adr[10]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_66_AN29
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[10]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_66_AN29
+set_property PACKAGE_PIN AR28              [get_ports "ddr4_sdram_c0_adr[11]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_66_AR28
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[11]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_66_AR28
+set_property PACKAGE_PIN AP30              [get_ports "ddr4_sdram_c0_adr[12]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_66_AP30
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[12]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_66_AP30
+set_property PACKAGE_PIN AU25              [get_ports "ddr4_sdram_c0_adr[13]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_T1U_N12_66_AU25
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[13]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_T1U_N12_66_AU25
+set_property PACKAGE_PIN AP29              [get_ports "ddr4_sdram_c0_adr[2]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_66_AP29
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[2]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_66_AP29
+set_property PACKAGE_PIN AT30              [get_ports "ddr4_sdram_c0_adr[3]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_66_AT30
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[3]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_66_AT30
+set_property PACKAGE_PIN AL30              [get_ports "ddr4_sdram_c0_adr[4]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_66_AL30
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[4]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_66_AL30
+set_property PACKAGE_PIN AT26              [get_ports "ddr4_sdram_c0_adr[5]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_66_AT26
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[5]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_66_AT26
+set_property PACKAGE_PIN AL31              [get_ports "ddr4_sdram_c0_adr[6]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L1N_T0L_N1_DBC_66_AL31
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[6]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L1N_T0L_N1_DBC_66_AL31
+set_property PACKAGE_PIN AU26              [get_ports "ddr4_sdram_c0_adr[7]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_66_AU26
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[7]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_66_AU26
+set_property PACKAGE_PIN AT28              [get_ports "ddr4_sdram_c0_adr[8]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_66_AT28
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[8]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_66_AT28
+set_property PACKAGE_PIN AR29              [get_ports "ddr4_sdram_c0_adr[9]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_66_AR29
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[9]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_66_AR29
+set_property PACKAGE_PIN AM27              [get_ports "ddr4_sdram_c0_act_n"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_66_AM27
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_act_n"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_66_AM27
+set_property PACKAGE_PIN AN30              [get_ports "ddr4_sdram_c0_ba[0]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_66_AN30
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_ba[0]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_66_AN30
+set_property PACKAGE_PIN AU27              [get_ports "ddr4_sdram_c0_ba[1]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_66_AU27
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_ba[1]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_66_AU27
+set_property PACKAGE_PIN AK26              [get_ports "ddr4_sdram_c0_bg[0]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_66_AK26
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_bg[0]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_66_AK26
+set_property PACKAGE_PIN AR27              [get_ports "ddr4_sdram_c0_adr[15]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_66_AR27
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[15]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_66_AR27
+set_property PACKAGE_PIN AU30              [get_ports "ddr4_sdram_c0_ck_c"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L7N_T1L_N1_QBC_AD13N_66_AU30
+set_property IOSTANDARD DIFF_SSTL12_DCI    [get_ports "ddr4_sdram_c0_ck_c"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L7N_T1L_N1_QBC_AD13N_66_AU30
+set_property PACKAGE_PIN AT29              [get_ports "ddr4_sdram_c0_ck_t"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_66_AT29
+set_property IOSTANDARD DIFF_SSTL12_DCI    [get_ports "ddr4_sdram_c0_ck_t"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_66_AT29
+set_property PACKAGE_PIN AL26              [get_ports "ddr4_sdram_c0_cke"]           ;#  Bank  66 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_66_AL26
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_cke"]           ;#  Bank  66 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_66_AL26
+set_property PACKAGE_PIN AM31              [get_ports "ddr4_sdram_c0_cs_n"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_66_AM31
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_cs_n"]          ;#  Bank  66 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_66_AM31
+set_property PACKAGE_PIN AN37              [get_ports "ddr4_sdram_c0_dm_n[0]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_67_AN37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[0]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_67_AN37
+set_property PACKAGE_PIN AK29              [get_ports "ddr4_sdram_c0_dm_n[1]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_66_AK29#
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[1]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_66_AK29
+set_property PACKAGE_PIN Y33               [get_ports "ddr4_sdram_c0_dm_n[2]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_68_Y33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[2]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_68_Y33
+set_property PACKAGE_PIN AB36              [get_ports "ddr4_sdram_c0_dm_n[3]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_68_AB36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[3]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_68_AB36
+set_property PACKAGE_PIN AM36              [get_ports "ddr4_sdram_c0_dm_n[4]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_67_AM36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[4]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_67_AM36
+set_property PACKAGE_PIN AH37              [get_ports "ddr4_sdram_c0_dm_n[5]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_67_AH37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[5]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L19P_T3L_N0_DBC_AD9P_67_AH37
+set_property PACKAGE_PIN AC37              [get_ports "ddr4_sdram_c0_dm_n[6]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_68_AC37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[6]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L7P_T1L_N0_QBC_AD13P_68_AC37
+set_property PACKAGE_PIN AE32              [get_ports "ddr4_sdram_c0_dm_n[7]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_68_AE32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[7]"]       ;#  Bank  68 VCCO - 1V2_VCCO - IO_L13P_T2L_N0_GC_QBC_68_AE32
+set_property PACKAGE_PIN AU31              [get_ports "ddr4_sdram_c0_dm_n[8]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_67_AU31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dm_n[8]"]       ;#  Bank  67 VCCO - 1V2_VCCO - IO_L1P_T0L_N0_DBC_67_AU31
+set_property PACKAGE_PIN AM35              [get_ports "ddr4_sdram_c0_dq[0]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L12P_T1U_N10_GC_67_AM35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[0]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L12P_T1U_N10_GC_67_AM35
+set_property PACKAGE_PIN AP34              [get_ports "ddr4_sdram_c0_dq[1]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_67_AP34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[1]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_67_AP34
+set_property PACKAGE_PIN AJ31              [get_ports "ddr4_sdram_c0_dq[10]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_66_AJ31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[10]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_66_AJ31
+set_property PACKAGE_PIN AG31              [get_ports "ddr4_sdram_c0_dq[11]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_66_AG31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[11]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_66_AG31
+set_property PACKAGE_PIN AH29              [get_ports "ddr4_sdram_c0_dq[12]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_66_AH29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[12]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_66_AH29
+set_property PACKAGE_PIN AF30              [get_ports "ddr4_sdram_c0_dq[13]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_66_AF30
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[13]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_66_AF30
+set_property PACKAGE_PIN AJ30              [get_ports "ddr4_sdram_c0_dq[14]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_66_AJ30
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[14]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_66_AJ30
+set_property PACKAGE_PIN AF29              [get_ports "ddr4_sdram_c0_dq[15]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_66_AF29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[15]"]        ;#  Bank  66 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_66_AF29
+set_property PACKAGE_PIN AB32              [get_ports "ddr4_sdram_c0_dq[16]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_68_AB32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[16]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_68_AB32
+set_property PACKAGE_PIN Y32               [get_ports "ddr4_sdram_c0_dq[17]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_68_Y32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[17]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_68_Y32
+set_property PACKAGE_PIN W32               [get_ports "ddr4_sdram_c0_dq[18]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_68_W32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[18]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_68_W32
+set_property PACKAGE_PIN W31               [get_ports "ddr4_sdram_c0_dq[19]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_68_W31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[19]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_68_W31
+set_property PACKAGE_PIN AN33              [get_ports "ddr4_sdram_c0_dq[2]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_67_AN33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[2]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_67_AN33
+set_property PACKAGE_PIN AB31              [get_ports "ddr4_sdram_c0_dq[20]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_68_AB31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[20]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_68_AB31
+set_property PACKAGE_PIN W30               [get_ports "ddr4_sdram_c0_dq[21]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_68_W30
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[21]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_68_W30
+set_property PACKAGE_PIN AA29              [get_ports "ddr4_sdram_c0_dq[22]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_68_AA29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[22]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_68_AA29
+set_property PACKAGE_PIN Y29               [get_ports "ddr4_sdram_c0_dq[23]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_68_Y29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[23]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_68_Y29
+set_property PACKAGE_PIN Y34               [get_ports "ddr4_sdram_c0_dq[24]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_68_Y34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[24]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_68_Y34
+set_property PACKAGE_PIN AA35              [get_ports "ddr4_sdram_c0_dq[25]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L5N_T0U_N9_AD14N_68_AA35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[25]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L5N_T0U_N9_AD14N_68_AA35
+set_property PACKAGE_PIN W36               [get_ports "ddr4_sdram_c0_dq[26]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_68_W36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[26]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_68_W36
+set_property PACKAGE_PIN AA34              [get_ports "ddr4_sdram_c0_dq[27]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_68_AA34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[27]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_68_AA34
+set_property PACKAGE_PIN AA36              [get_ports "ddr4_sdram_c0_dq[28]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_68_AA36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[28]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_68_AA36
+set_property PACKAGE_PIN W37               [get_ports "ddr4_sdram_c0_dq[29]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_68_W37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[29]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_68_W37
+set_property PACKAGE_PIN AN34              [get_ports "ddr4_sdram_c0_dq[3]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_67_AN34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[3]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_67_AN34
+set_property PACKAGE_PIN Y36               [get_ports "ddr4_sdram_c0_dq[30]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_68_Y36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[30]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_68_Y36
+set_property PACKAGE_PIN AB35              [get_ports "ddr4_sdram_c0_dq[31]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_68_AB35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[31]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_68_AB35
+set_property PACKAGE_PIN AL34              [get_ports "ddr4_sdram_c0_dq[32]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_67_AL34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[32]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_67_AL34
+set_property PACKAGE_PIN AL36              [get_ports "ddr4_sdram_c0_dq[33]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L14N_T2L_N3_GC_67_AL36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[33]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L14N_T2L_N3_GC_67_AL36
+set_property PACKAGE_PIN AL35              [get_ports "ddr4_sdram_c0_dq[34]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L14P_T2L_N2_GC_67_AL35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[34]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L14P_T2L_N2_GC_67_AL35
+set_property PACKAGE_PIN AK36              [get_ports "ddr4_sdram_c0_dq[35]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L17P_T2U_N8_AD10P_67_AK36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[35]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L17P_T2U_N8_AD10P_67_AK36
+set_property PACKAGE_PIN AL33              [get_ports "ddr4_sdram_c0_dq[36]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L15P_T2L_N4_AD11P_67_AL33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[36]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L15P_T2L_N4_AD11P_67_AL33
+set_property PACKAGE_PIN AK37              [get_ports "ddr4_sdram_c0_dq[37]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L17N_T2U_N9_AD10N_67_AK37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[37]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L17N_T2U_N9_AD10N_67_AK37
+set_property PACKAGE_PIN AJ36              [get_ports "ddr4_sdram_c0_dq[38]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L18N_T2U_N11_AD2N_67_AJ36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[38]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L18N_T2U_N11_AD2N_67_AJ36
+set_property PACKAGE_PIN AJ35              [get_ports "ddr4_sdram_c0_dq[39]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L18P_T2U_N10_AD2P_67_AJ35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[39]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L18P_T2U_N10_AD2P_67_AJ35
+set_property PACKAGE_PIN AM33              [get_ports "ddr4_sdram_c0_dq[4]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_67_AM33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[4]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_67_AM33
+set_property PACKAGE_PIN AG35              [get_ports "ddr4_sdram_c0_dq[40]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_67_AG35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[40]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L23P_T3U_N8_67_AG35
+set_property PACKAGE_PIN AH32              [get_ports "ddr4_sdram_c0_dq[41]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_67_AH32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[41]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L21P_T3L_N4_AD8P_67_AH32
+set_property PACKAGE_PIN AH35              [get_ports "ddr4_sdram_c0_dq[42]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_67_AH35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[42]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L23N_T3U_N9_67_AH35
+set_property PACKAGE_PIN AG37              [get_ports "ddr4_sdram_c0_dq[43]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_67_AG37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[43]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L24N_T3U_N11_67_AG37
+set_property PACKAGE_PIN AH34              [get_ports "ddr4_sdram_c0_dq[44]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_67_AH34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[44]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L20P_T3L_N2_AD1P_67_AH34
+set_property PACKAGE_PIN AJ32              [get_ports "ddr4_sdram_c0_dq[45]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_67_AJ32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[45]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_67_AJ32
+set_property PACKAGE_PIN AJ34              [get_ports "ddr4_sdram_c0_dq[46]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_67_AJ34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[46]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L20N_T3L_N3_AD1N_67_AJ34
+set_property PACKAGE_PIN AG36              [get_ports "ddr4_sdram_c0_dq[47]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_67_AG36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[47]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_67_AG36
+set_property PACKAGE_PIN AE36              [get_ports "ddr4_sdram_c0_dq[48]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_68_AE36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[48]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L9P_T1L_N4_AD12P_68_AE36
+set_property PACKAGE_PIN AC34              [get_ports "ddr4_sdram_c0_dq[49]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_68_AC34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[49]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_68_AC34
+set_property PACKAGE_PIN AR37              [get_ports "ddr4_sdram_c0_dq[5]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_67_AR37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[5]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_67_AR37
+set_property PACKAGE_PIN AD36              [get_ports "ddr4_sdram_c0_dq[50]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_68_AD36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[50]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_68_AD36
+set_property PACKAGE_PIN AD34              [get_ports "ddr4_sdram_c0_dq[51]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_68_AD34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[51]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L11N_T1U_N9_GC_68_AD34
+set_property PACKAGE_PIN AE37              [get_ports "ddr4_sdram_c0_dq[52]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_68_AE37
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[52]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L8N_T1L_N3_AD5N_68_AE37
+set_property PACKAGE_PIN AE34              [get_ports "ddr4_sdram_c0_dq[53]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L12P_T1U_N10_GC_68_AE34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[53]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L12P_T1U_N10_GC_68_AE34
+set_property PACKAGE_PIN AF36              [get_ports "ddr4_sdram_c0_dq[54]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_68_AF36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[54]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_68_AF36
+set_property PACKAGE_PIN AF34              [get_ports "ddr4_sdram_c0_dq[55]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_68_AF34
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[55]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_68_AF34
+set_property PACKAGE_PIN AB33              [get_ports "ddr4_sdram_c0_dq[56]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L18P_T2U_N10_AD2P_68_AB33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[56]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L18P_T2U_N10_AD2P_68_AB33
+set_property PACKAGE_PIN AD30              [get_ports "ddr4_sdram_c0_dq[57]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L14P_T2L_N2_GC_68_AD30
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[57]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L14P_T2L_N2_GC_68_AD30
+set_property PACKAGE_PIN AC33              [get_ports "ddr4_sdram_c0_dq[58]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L18N_T2U_N11_AD2N_68_AC33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[58]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L18N_T2U_N11_AD2N_68_AC33
+set_property PACKAGE_PIN AC32              [get_ports "ddr4_sdram_c0_dq[59]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L17P_T2U_N8_AD10P_68_AC32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[59]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L17P_T2U_N8_AD10P_68_AC32
+set_property PACKAGE_PIN AN35              [get_ports "ddr4_sdram_c0_dq[6]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_67_AN35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[6]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_67_AN35
+set_property PACKAGE_PIN AD32              [get_ports "ddr4_sdram_c0_dq[60]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L17N_T2U_N9_AD10N_68_AD32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[60]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L17N_T2U_N9_AD10N_68_AD32
+set_property PACKAGE_PIN AC29              [get_ports "ddr4_sdram_c0_dq[61]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L15P_T2L_N4_AD11P_68_AC29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[61]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L15P_T2L_N4_AD11P_68_AC29
+set_property PACKAGE_PIN AE31              [get_ports "ddr4_sdram_c0_dq[62]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L14N_T2L_N3_GC_68_AE31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[62]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L14N_T2L_N3_GC_68_AE31
+set_property PACKAGE_PIN AD29              [get_ports "ddr4_sdram_c0_dq[63]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_68_AD29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[63]"]        ;#  Bank  68 VCCO - 1V2_VCCO - IO_L15N_T2L_N5_AD11N_68_AD29
+set_property PACKAGE_PIN AU33              [get_ports "ddr4_sdram_c0_dq[64]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_67_AU33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[64]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L2N_T0L_N3_67_AU33
+set_property PACKAGE_PIN AT36              [get_ports "ddr4_sdram_c0_dq[65]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L5N_T0U_N9_AD14N_67_AT36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[65]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L5N_T0U_N9_AD14N_67_AT36
+set_property PACKAGE_PIN AT33              [get_ports "ddr4_sdram_c0_dq[66]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_67_AT33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[66]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L2P_T0L_N2_67_AT33
+set_property PACKAGE_PIN AR36              [get_ports "ddr4_sdram_c0_dq[67]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_67_AR36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[67]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L6N_T0U_N11_AD6N_67_AR36
+set_property PACKAGE_PIN AR32              [get_ports "ddr4_sdram_c0_dq[68]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_67_AR32
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[68]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L3P_T0L_N4_AD15P_67_AR32
+set_property PACKAGE_PIN AP35              [get_ports "ddr4_sdram_c0_dq[69]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_67_AP35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[69]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L6P_T0U_N10_AD6P_67_AP35
+set_property PACKAGE_PIN AP36              [get_ports "ddr4_sdram_c0_dq[7]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_67_AP36
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[7]"]         ;#  Bank  67 VCCO - 1V2_VCCO - IO_L8P_T1L_N2_AD5P_67_AP36
+set_property PACKAGE_PIN AT35              [get_ports "ddr4_sdram_c0_dq[70]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_67_AT35
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[70]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L5P_T0U_N8_AD14P_67_AT35
+set_property PACKAGE_PIN AR33              [get_ports "ddr4_sdram_c0_dq[71]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_67_AR33
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[71]"]        ;#  Bank  67 VCCO - 1V2_VCCO - IO_L3N_T0L_N5_AD15N_67_AR33
+set_property PACKAGE_PIN AJ29              [get_ports "ddr4_sdram_c0_dq[8]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_66_AJ29
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[8]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L21N_T3L_N5_AD8N_66_AJ29
+set_property PACKAGE_PIN AF31              [get_ports "ddr4_sdram_c0_dq[9]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_66_AF31
+set_property IOSTANDARD POD12_DCI          [get_ports "ddr4_sdram_c0_dq[9]"]         ;#  Bank  66 VCCO - 1V2_VCCO - IO_L24P_T3U_N10_66_AF31
+set_property PACKAGE_PIN AN32              [get_ports "ddr4_sdram_c0_dqs_c[0]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_67_AN32
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[0]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_67_AN32
+set_property PACKAGE_PIN AH30              [get_ports "ddr4_sdram_c0_dqs_c[1]"]      ;#  Bank  66 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_66_AH30
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[1]"]      ;#  Bank  66 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_66_AH30
+set_property PACKAGE_PIN AA31              [get_ports "ddr4_sdram_c0_dqs_c[2]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_68_AA31
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[2]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_68_AA31
+set_property PACKAGE_PIN W35               [get_ports "ddr4_sdram_c0_dqs_c[3]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_68_W35
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[3]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_68_W35
+set_property PACKAGE_PIN AK34              [get_ports "ddr4_sdram_c0_dqs_c[4]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_67_AK34
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[4]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_67_AK34
+set_property PACKAGE_PIN AG33              [get_ports "ddr4_sdram_c0_dqs_c[5]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_67_AG33
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[5]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L22N_T3U_N7_DBC_AD0N_67_AG33
+set_property PACKAGE_PIN AD35              [get_ports "ddr4_sdram_c0_dqs_c[6]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_68_AD35
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[6]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L10N_T1U_N7_QBC_AD4N_68_AD35
+set_property PACKAGE_PIN AD31              [get_ports "ddr4_sdram_c0_dqs_c[7]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_68_AD31
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[7]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L16N_T2U_N7_QBC_AD3N_68_AD31
+set_property PACKAGE_PIN AU35              [get_ports "ddr4_sdram_c0_dqs_c[8]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_67_AU35
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_c[8]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L4N_T0U_N7_DBC_AD7N_67_AU35
+set_property PACKAGE_PIN AM32              [get_ports "ddr4_sdram_c0_dqs_t[0]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_67_AM32
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[0]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_67_AM32
+set_property PACKAGE_PIN AG30              [get_ports "ddr4_sdram_c0_dqs_t[1]"]      ;#  Bank  66 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_66_AG30
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[1]"]      ;#  Bank  66 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_66_AG30
+set_property PACKAGE_PIN Y31               [get_ports "ddr4_sdram_c0_dqs_t[2]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_68_Y31
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[2]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_68_Y31
+set_property PACKAGE_PIN W34               [get_ports "ddr4_sdram_c0_dqs_t[3]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_68_W34
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[3]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_68_W34
+set_property PACKAGE_PIN AK33              [get_ports "ddr4_sdram_c0_dqs_t[4]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_67_AK33
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[4]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_67_AK33
+set_property PACKAGE_PIN AF33              [get_ports "ddr4_sdram_c0_dqs_t[5]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_67_AF33
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[5]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L22P_T3U_N6_DBC_AD0P_67_AF33
+set_property PACKAGE_PIN AC35              [get_ports "ddr4_sdram_c0_dqs_t[6]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_68_AC35
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[6]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L10P_T1U_N6_QBC_AD4P_68_AC35
+set_property PACKAGE_PIN AC30              [get_ports "ddr4_sdram_c0_dqs_t[7]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_68_AC30
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[7]"]      ;#  Bank  68 VCCO - 1V2_VCCO - IO_L16P_T2U_N6_QBC_AD3P_68_AC30
+set_property PACKAGE_PIN AT34              [get_ports "ddr4_sdram_c0_dqs_t[8]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_67_AT34
+set_property IOSTANDARD DIFF_POD12_DCI     [get_ports "ddr4_sdram_c0_dqs_t[8]"]      ;#  Bank  67 VCCO - 1V2_VCCO - IO_L4P_T0U_N6_DBC_AD7P_67_AT34
+set_property PACKAGE_PIN AP27              [get_ports "ddr4_sdram_c0_odt"]           ;#  Bank  66 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_66_AP27
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_odt"]           ;#  Bank  66 VCCO - 1V2_VCCO - IO_L12N_T1U_N11_GC_66_AP27
+set_property PACKAGE_PIN AU28              [get_ports "ddr4_sdram_c0_adr[16]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_66_AU28
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[16]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L9N_T1L_N5_AD12N_66_AU28
+set_property PACKAGE_PIN AR26              [get_ports "ddr4_sdram_c0_adr[14]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_66_AR26
+set_property IOSTANDARD SSTL12_DCI         [get_ports "ddr4_sdram_c0_adr[14]"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_L11P_T1U_N8_GC_66_AR26
+set_property PACKAGE_PIN AK31              [get_ports "ddr4_sdram_c0_reset_n"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_T3U_N12_66_AK31
+set_property IOSTANDARD LVCMOS12           [get_ports "ddr4_sdram_c0_reset_n"]       ;#  Bank  66 VCCO - 1V2_VCCO - IO_T3U_N12_66_AK31

--- a/board/x3522pv/uart.xdc
+++ b/board/x3522pv/uart.xdc
@@ -1,0 +1,3 @@
+# UART
+set_property -dict {PACKAGE_PIN AP24 IOSTANDARD LVCMOS18} [get_ports usb_uart_txd]
+set_property -dict {PACKAGE_PIN AR24 IOSTANDARD LVCMOS18} [get_ports usb_uart_rxd]


### PR DESCRIPTION
Adding support for the [Alveo X3522PV](https://www.amd.com/en/products/accelerators/alveo/x3/a-x3522pv-p08g-pq-g.html) board (nickname 'X3'), which is a speedgrade-3 Ultrascale+. 
Confirmed works in the lab for both baremetal and Linux on 32bit Rocket, and several flavors of 64bit Rocket and 64bit BOOM, including megaBOOM.
I used the VCU1525 board as a starting point; the main difference is that VCU1525 has Xilinx board file support for DDR4 whereas for X3 I had to hook up the pins explicitly. 
Speedgrade-3 board allows pushing the clock frequencies higher.
One difference from VCU1525 support is I chose to go with XDMA instead of QDMA for the PCIe, because it's simpler to use and verify. But it wouldn't be difficult to change it to QDMA.